### PR TITLE
Add MPC feature ndds_no_optimize

### DIFF
--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -7,6 +7,9 @@
 // --------------------------------------------------------------------
 
 feature(ddsx11, ndds) : ndds_ts_defaults {
+}
+
+feature(ddsx11, ndds_no_optimize) : ndds_ts_defaults {
   // rtiddsgen has multiple optimization modes (see -help)
   // The ddsx11 conversion traits are based on the fact that for each c++11
   // type there is a c++ equivalent, with optimizations enabled it

--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -7,6 +7,13 @@
 // --------------------------------------------------------------------
 
 feature(ddsx11, ndds) : ndds_ts_defaults {
+  // rtiddsgen has multiple optimization modes (see -help)
+  // The ddsx11 conversion traits are based on the fact that for each c++11
+  // type there is a c++ equivalent, with optimizations enabled it
+  // can happen that the c++ equivalent is not there which means the
+  // generated code is not following the IDL to C++ language mapping which
+  // leads to compile errors
+  ndds_ts_flags += -optimization 0
 }
 
 feature(!ndds) {

--- a/ddsx11/vendors/ndds/etc/configurerc
+++ b/ddsx11/vendors/ndds/etc/configurerc
@@ -23,6 +23,7 @@ configure :ddsx11ndds do
     end
 
     optional :ndds_no_optimize do
+      file '${NDDSHOME}/bin/rtiddsgen'
       evaluate(:rttiddsgen) do
         rtiddsgen_ver_ = `#{getenv('NDDSHOME')}/bin/rtiddsgen -version | grep 'rtiddsgen version'`.chomp.split(' ').last
         rtiddsgen_ver_ >= '3.0.0'


### PR DESCRIPTION
The MPC feature ndds_no_optimize has to be defined to 1 with rtiddsgen 3.0.0 or newer. This disables some optimizations in rtiddsgen which leads to generated code which is not compliant with the IDL to C++ language mapping