### PR TITLE
Updated for improved escaping.

### DIFF
--- a/tests/attribute_keyword/component/foo.idl
+++ b/tests/attribute_keyword/component/foo.idl
@@ -12,15 +12,14 @@
 
 #include <Components.idl>
 
-//TODO change __char into _char
 struct Bar
 {
-  short __char;
+  short _char;
 };
 
 interface MyFoo
 {
-    attribute short __short;
+    attribute short _short;
     attribute short while;
 };
 

--- a/tests/attribute_keyword/component/foo_exec.cpp
+++ b/tests/attribute_keyword/component/foo_exec.cpp
@@ -70,19 +70,19 @@ namespace Foo_Impl
   /** Operations and attributes from my_foo_prov */
 
   int16_t
-  my_foo_prov_exec_i::_short ()
+  my_foo_prov_exec_i::_cxx_short ()
   {
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Foo_Impl::my_foo_prov_exec_i::_short[getter]
-    return this->_short_;
+    return this->_cxx_short_;
     //@@{__RIDL_REGEN_MARKER__} - END : Foo_Impl::my_foo_prov_exec_i::_short[getter]
   }
 
   void
-  my_foo_prov_exec_i::_short (
-      int16_t _short)
+  my_foo_prov_exec_i::_cxx_short (
+      int16_t _cxx_short)
   {
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Foo_Impl::my_foo_prov_exec_i::_short[setter]
-    this->_short_ = _short;
+    this->_cxx_short_ = _cxx_short;
     //@@{__RIDL_REGEN_MARKER__} - END : Foo_Impl::my_foo_prov_exec_i::_short[setter]
   }
 
@@ -393,11 +393,11 @@ namespace Foo_Impl
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Foo_Impl::Foo_exec_i::override[setter]
     this->override_attribute_success_ = true;
 
-    if (override._char() != 3)
+    if (override._cxx_char() != 3)
     {
       this->override_attribute_success_ = false;
       CIAOX11_TEST_ERROR << "ERROR: override char value != 3, it is "
-                           <<  override._char() << std::endl;
+                           <<  override._cxx_char() << std::endl;
     }
     //@@{__RIDL_REGEN_MARKER__} - END : Foo_Impl::Foo_exec_i::override[setter]
   }

--- a/tests/attribute_keyword/component/foo_exec.h
+++ b/tests/attribute_keyword/component/foo_exec.h
@@ -59,12 +59,12 @@ namespace Foo_Impl
 
     virtual
     int16_t
-    _short () override;
+    _cxx_short () override;
 
     virtual
     void
-    _short (
-        int16_t _short) override;
+    _cxx_short (
+        int16_t _cxx_short) override;
 
     virtual
     int16_t
@@ -90,7 +90,7 @@ namespace Foo_Impl
     /** @name Members to store attribute values from CCM_MyFoo */
     //@{
     /// Class member storing value of _short attribute
-    int16_t _short_ {};
+    int16_t _cxx_short_ {};
     /// Class member storing value of while attribute
     int16_t _cxx_while_ {};
     //@}


### PR DESCRIPTION
    * tests/attribute_keyword/component/foo.idl:
    * tests/attribute_keyword/component/foo_exec.cpp:
    * tests/attribute_keyword/component/foo_exec.h: