### PR TITLE
Add -enableEscapeChar to the default ndds flags, makes sure a escape …

### DIFF
--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------
 
 feature(ddsx11, ndds) : ndds_ts_defaults {
+  ndds_ts_flags += -enableEscapeChar
 }
 
 feature(ddsx11, ndds_no_optimize) : ndds_ts_defaults {


### PR DESCRIPTION
…character is removed, but RTI Connext DDS doesn't implement all necessary support yet

    * ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb: