### PR TITLE
Add idl tests to the lst files

### DIFF
--- a/bin/ciaox11_tests.lst
+++ b/bin/ciaox11_tests.lst
@@ -10,6 +10,8 @@ examples/hello/basic/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 examples/hello/extended/descriptors/run_test.pl: CORBA4CCM
 examples/apc/apc_sync_default/descriptors/run_test.pl: CORBA4CCM
 examples/apc/apc_sync_extended/descriptors/run_test.pl: CORBA4CCM
+tests/apc/async-event-combi/descriptors/run_test.pl plan_ndds.config: DDS4CCM_EVENT AMI4CCM CORBA4CCM NDDS
+tests/apc/async-event-combi/descriptors/run_test.pl plan_opendds.config: DDS4CCM_EVENT AMI4CCM CORBA4CCM OPENDDS
 tests/apc/ext-sync-complex/descriptors/run_test.pl: CORBA4CCM
 tests/apc/ext-sync-explicit/descriptors/run_test.pl: CORBA4CCM
 tests/apc/ext-sync-extra/descriptors/run_test.pl: CORBA4CCM
@@ -25,18 +27,12 @@ tests/apc/minimal-sync-data/descriptors/run_test.pl: CORBA4CCM
 tests/apc/minimal-sync-data-nocode/descriptors/run_test.pl: CORBA4CCM
 tests/apc/minimal-sync-data-nocode-combined/descriptors/run_test.pl: CORBA4CCM
 tests/apc/minimal-async/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-tests/apc/async-event-combi/descriptors/run_test.pl plan_ndds.config: DDS4CCM_EVENT AMI4CCM CORBA4CCM NDDS
-tests/apc/async-event-combi/descriptors/run_test.pl plan_opendds.config: DDS4CCM_EVENT AMI4CCM CORBA4CCM OPENDDS
 tests/apc/sync-all-in-one/descriptors/run_test.pl: CORBA4CCM
-tests/attributes/descriptors/run_test.pl:
 tests/attribute_keyword/descriptors/run_test.pl:
+tests/attributes/descriptors/run_test.pl:
 tests/bst_test/assemblies/bst_asm/deployment/descriptors/run_test.pl: CORBA4CCM
 tests/conn_test/descriptors/run_test.pl: CORBA4CCM
 tests/conn_test/descriptors/run_test.pl -fmt cdp: CORBA4CCM
-tests/gen_test/descriptors/run_test.pl: CORBA4CCM
-tests/gen_test_simple/descriptors/run_test.pl: CORBA4CCM
-tests/log_test_env/run_test.pl: CORBA4CCM
-tests/log_test/run_test.pl: CORBA4CCM
 tests/dance/execution_manager/descriptors/run_test.pl: CORBA4CCM
 tests/dance/execution_manager/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 tests/dance/execution_manager/descriptors/run_test_pl.pl: CORBA4CCM
@@ -47,6 +43,12 @@ tests/dance/staged/descriptors/run_test.pl: CORBA4CCM
 tests/dance/staged/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 tests/external/servant/descriptors/run_test.pl: CORBA4CCM
 tests/external/servant/descriptors/run_test.pl -fmt cdp: CORBA4CCM
+tests/gen_test/descriptors/run_test.pl: CORBA4CCM
+tests/gen_test_simple/descriptors/run_test.pl: CORBA4CCM
+tests/keywords/run_test.pl: CORBA4CCM
+tests/kitchensink/run_test.pl: CORBA4CCM
+tests/log_test/run_test.pl: CORBA4CCM
+tests/log_test_env/run_test.pl: CORBA4CCM
 tests/multiple/descriptors/run_test.pl: CORBA4CCM
 tests/multiple/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 tests/naming_context/deregistration/descriptors/run_test.pl: CORBA4CCM
@@ -57,46 +59,49 @@ tests/starter_code_test/descriptors/run_test.pl: CORBA4CCM
 tests/starter_code_test/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 connectors/ami4ccm/tutorials/hello/hello_asm/deployment/scripts/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tutorials/hello/hello_asm/deployment/scripts/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/examples/apc/apc_hello_simple/descriptors/run_test.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/examples/hello_extended/descriptors/run_test.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/examples/hello_simple/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/apc/apc_async_extended/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/apc/gen_comp/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/apc/simplexmulti/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/apc/usesmulti/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test_pl.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test_pl.pl -fmt cdp : AMI4CCM CORBA4CCM
-connectors/ami4ccm/examples/hello_simple/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/examples/hello_extended/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/examples/apc/apc_hello_simple/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/export_test_ami/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/export_test_ami/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_exceptions/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_exceptions/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_gen_test/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_gen_test/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_in_args/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_in_args/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_out_args/descriptors/run_test.pl: AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_out_args/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_inout_args/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_inout_args/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_multi_inher/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_multi_inher/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_no_corba/descriptors/run_test.pl: AMI4CCM
+connectors/ami4ccm/tests/asyn_no_corba/descriptors/run_test.pl -fmt cdp : AMI4CCM
 connectors/ami4ccm/tests/asyn_no_reply/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_no_reply/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_out_args/descriptors/run_test.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_out_args/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_return/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/asyn_return/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test_pl.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/asyn_with_syn_facet/descriptors/run_test_pl.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/export_test_ami/descriptors/run_test.pl: AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/export_test_ami/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
+connectors/ami4ccm/tests/idl_test/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/no_connection/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/no_connection/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/simplexmulti/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/simplexmulti/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/usesmulti/descriptors/run_test.pl: AMI4CCM CORBA4CCM
 connectors/ami4ccm/tests/usesmulti/descriptors/run_test.pl -fmt cdp : AMI4CCM CORBA4CCM
-connectors/ami4ccm/tests/asyn_no_corba/descriptors/run_test.pl: AMI4CCM
-connectors/ami4ccm/tests/asyn_no_corba/descriptors/run_test.pl -fmt cdp : AMI4CCM
-connectors/corba4ccm/tests/exceptions/descriptors/run_test.pl: CORBA4CCM
 connectors/corba4ccm/examples/local_and_remote/descriptors/run_test.pl: CORBA4CCM
 connectors/corba4ccm/examples/remote_and_colocated/descriptors/run_test.pl: CORBA4CCM
 connectors/corba4ccm/tests/apc/usesmulti/descriptors/run_test.pl: CORBA4CCM
+connectors/corba4ccm/tests/exceptions/descriptors/run_test.pl: CORBA4CCM
+connectors/corba4ccm/tests/idl_tests/derived/descriptors/run_test.pl: CORBA4CCM
+connectors/corba4ccm/tests/idl_tests/multi_modules/descriptors/run_test.pl: CORBA4CCM
 connectors/tt4ccm/tests/apc/basic/descriptors/run_test.pl:
 connectors/tt4ccm/tests/apc/gen_comp/descriptors/run_test.pl:
 connectors/tt4ccm/tests/basic/descriptors/run_test.pl:

--- a/bin/ciaox11_tests.lst
+++ b/bin/ciaox11_tests.lst
@@ -45,8 +45,8 @@ tests/external/servant/descriptors/run_test.pl: CORBA4CCM
 tests/external/servant/descriptors/run_test.pl -fmt cdp: CORBA4CCM
 tests/gen_test/descriptors/run_test.pl: CORBA4CCM
 tests/gen_test_simple/descriptors/run_test.pl: CORBA4CCM
-tests/keywords/run_test.pl: CORBA4CCM
-tests/kitchensink/run_test.pl: CORBA4CCM
+tests/keywords/run_test.pl:
+tests/kitchensink/run_test.pl:
 tests/log_test/run_test.pl: CORBA4CCM
 tests/log_test_env/run_test.pl: CORBA4CCM
 tests/multiple/descriptors/run_test.pl: CORBA4CCM

--- a/connectors/ami4ccm/tests/idl_test/descriptors/run_test.pl
+++ b/connectors/ami4ccm/tests/idl_test/descriptors/run_test.pl
@@ -1,0 +1,13 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Johnny Willemsen
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+exit 0;

--- a/connectors/corba4ccm/tests/idl_tests/derived/descriptors/run_test.pl
+++ b/connectors/corba4ccm/tests/idl_tests/derived/descriptors/run_test.pl
@@ -1,0 +1,13 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Johnny Willemsen
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+exit 0;

--- a/connectors/corba4ccm/tests/idl_tests/multi_modules/descriptors/run_test.pl
+++ b/connectors/corba4ccm/tests/idl_tests/multi_modules/descriptors/run_test.pl
@@ -1,0 +1,13 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Johnny Willemsen
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+exit 0;

--- a/ridlbe/ccmx11/templates/lem_idl/component_lem.erb
+++ b/ridlbe/ccmx11/templates/lem_idl/component_lem.erb
@@ -11,7 +11,7 @@ local interface <%= ccm_name %>
 %   if _p.port_type == :facet
   /// Factory method and getter for the <%= _p.lem_name %> facet
   /// @return existing instance of facet if one exists, else creates one
-  <%= _p.interface_type.scoped_ccm_name %> get_<%= _p.lem_name %> ();
+  <%= _p.interface_type.scoped_unescaped_ccm_name %> get_<%= _p.lem_name %> ();
 %   end
 %   if _p.port_type == :receptacle && _p.is_multiple?
   struct <%= _p.lem_name %>Connection {

--- a/tests/keywords/descriptors/run_test.pl
+++ b/tests/keywords/descriptors/run_test.pl
@@ -1,0 +1,13 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Johnny Willemsen
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+exit 0;

--- a/tests/kitchensink/descriptors/run_test.pl
+++ b/tests/kitchensink/descriptors/run_test.pl
@@ -1,0 +1,13 @@
+#---------------------------------------------------------------------
+# @file   run_test.pl
+# @author Johnny Willemsen
+#
+# @copyright Copyright (c) Remedy IT Expertise BV
+#---------------------------------------------------------------------
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+exit 0;


### PR DESCRIPTION
    * connectors/ami4ccm/tests/idl_test/descriptors/run_test.pl:
    * connectors/corba4ccm/tests/idl_tests/derived/descriptors/run_test.pl:
    * connectors/corba4ccm/tests/idl_tests/multi_modules/descriptors/run_test.pl:
    * tests/keywords/descriptors/run_test.pl:
    * tests/kitchensink/descriptors/run_test.pl:
      Added, simpy noop tests but this way we can add them to the lst file

    * bin/ciaox11_tests.lst:
      Add all idl tests so that they are compiled with a brix11 make

    * ridlbe/ccmx11/templates/lem_idl/component_lem.erb:
      Use unescaped interface name when generating IDL