### PR TITLE
Mark constructors with a single argument as explicit

### DIFF
--- a/connectors/dds4ccm/examples/custom/src/sender/custom_example_sender_exec.cpp
+++ b/connectors/dds4ccm/examples/custom/src/sender/custom_example_sender_exec.cpp
@@ -27,7 +27,7 @@ namespace Example_BasicPublisher_comp_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::Example::CCM_BasicPublisher_comp>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::Example::CCM_BasicPublisher_comp>::weak_ref_type component_executor)
     : component_executor_(component_executor)
      {}
 

--- a/connectors/dds4ccm/examples/idl/sender/idl_example_sender_exec.cpp
+++ b/connectors/dds4ccm/examples/idl/sender/idl_example_sender_exec.cpp
@@ -26,7 +26,7 @@ namespace Example_BasicPublisher_comp_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::Example::CCM_BasicPublisher_comp>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::Example::CCM_BasicPublisher_comp>::weak_ref_type component_executor)
     : component_executor_(component_executor)
      {}
 

--- a/connectors/dds4ccm/examples/shapes_asm/shapes_control_comp/src/shapes_control_comp_exec.cpp
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_control_comp/src/shapes_control_comp_exec.cpp
@@ -26,7 +26,7 @@ namespace Shapes_Control_comp_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::Shapes::CCM_Control_comp>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::Shapes::CCM_Control_comp>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/apc/gen_comp/components/publisher/publisher_exec.cpp
+++ b/connectors/dds4ccm/tests/apc/gen_comp/components/publisher/publisher_exec.cpp
@@ -24,7 +24,7 @@ namespace publisher_comp_Impl
   class TT_Callback final : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits<CCM_publisher_comp>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits<CCM_publisher_comp>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/coherent_write/receiver/coherent_writer_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/coherent_write/receiver/coherent_writer_receiver_exec.cpp
@@ -24,7 +24,7 @@ namespace CoherentWriter_Receiver_Impl
     : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::CoherentWriter::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::CoherentWriter::CCM_Receiver>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/common/ticker_t.h
+++ b/connectors/dds4ccm/tests/common/ticker_t.h
@@ -23,7 +23,7 @@ namespace DDS4CCM_TEST_UTILS
     : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    ContextSwitch (EXECUTOR component_executor)
+    explicit ContextSwitch (EXECUTOR component_executor)
       : component_executor_ (std::move(component_executor))
     {
     }

--- a/connectors/dds4ccm/tests/connector_status_listener/components/receiver/csl_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/connector_status_listener/components/receiver/csl_receiver_exec.cpp
@@ -25,7 +25,7 @@ namespace CSL_Test_Receiver_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::CSL_Test::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::CSL_Test::CCM_Receiver>::weak_ref_type component_executor)
     :  component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/connector_status_listener/components/sender/csl_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/connector_status_listener/components/sender/csl_sender_exec.cpp
@@ -25,7 +25,7 @@ namespace CSL_Test_Sender_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::CSL_Test::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::CSL_Test::CCM_Sender>::weak_ref_type component_executor)
              : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/filters/filter_attrib/read_get/receiver/fa_rg_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/read_get/receiver/fa_rg_receiver_exec.cpp
@@ -113,7 +113,7 @@ namespace FA_Read_Get_Test_Receiver_Impl
   :  public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::FA_Read_Get_Test::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::FA_Read_Get_Test::CCM_Receiver>::weak_ref_type component_executor)
                  : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/filters/query_attrib/read_get/receiver/qa_rg_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/filters/query_attrib/read_get/receiver/qa_rg_receiver_exec.cpp
@@ -110,7 +110,7 @@ namespace QA_Read_Get_Test_Receiver_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::QA_Read_Get_Test::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::QA_Read_Get_Test::CCM_Receiver>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/late_binded/read_get/receiver/rg_late_bind_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/late_binded/read_get/receiver/rg_late_bind_receiver_exec.cpp
@@ -27,7 +27,7 @@ namespace RG_LateBinding_Receiver_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::RG_LateBinding::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::RG_LateBinding::CCM_Receiver>::weak_ref_type component_executor)
             : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/max_delivered_data/getter/receiver/mdd_getter_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/max_delivered_data/getter/receiver/mdd_getter_receiver_exec.cpp
@@ -26,7 +26,7 @@ namespace MDD_Getter_Test_Receiver_Impl
      : public IDL::traits<CCM_TT::TT_Handler>::base_type
    {
    public:
-     TT_Callback (IDL::traits< ::MDD_Getter_Test::CCM_Receiver_Context>::ref_type ctx)
+     explicit TT_Callback (IDL::traits< ::MDD_Getter_Test::CCM_Receiver_Context>::ref_type ctx)
           : ciao_context_ (ctx)
      {}
 

--- a/connectors/dds4ccm/tests/max_delivered_data/getter/sender/mdd_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/max_delivered_data/getter/sender/mdd_sender_exec.cpp
@@ -26,7 +26,7 @@ namespace MDD_Test_Sender_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
             : component_executor_(component_executor)
     {
     }

--- a/connectors/dds4ccm/tests/max_delivered_data/listeners/data/sender/mdd_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/max_delivered_data/listeners/data/sender/mdd_sender_exec.cpp
@@ -26,7 +26,7 @@ namespace MDD_Test_Sender_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
             : component_executor_(component_executor)
     {
     }

--- a/connectors/dds4ccm/tests/max_delivered_data/listeners/state/sender/mdd_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/max_delivered_data/listeners/state/sender/mdd_sender_exec.cpp
@@ -26,7 +26,7 @@ namespace MDD_Test_Sender_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::MDD_Test::CCM_Sender>::weak_ref_type component_executor)
             : component_executor_(component_executor)
     {
     }

--- a/connectors/dds4ccm/tests/port_status_listener/deadline_missed/receiver/psl_deadline_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/port_status_listener/deadline_missed/receiver/psl_deadline_receiver_exec.cpp
@@ -26,7 +26,7 @@ namespace PSL_DeadlineTest_Receiver_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::PSL_DeadlineTest::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::PSL_DeadlineTest::CCM_Receiver>::weak_ref_type component_executor)
               : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/port_status_listener/deadline_missed/sender/psl_deadline_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/port_status_listener/deadline_missed/sender/psl_deadline_sender_exec.cpp
@@ -27,7 +27,7 @@ namespace PSL_DeadlineTest_Sender_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
     public:
-    TT_Callback (IDL::traits< ::PSL_DeadlineTest::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::PSL_DeadlineTest::CCM_Sender>::weak_ref_type component_executor)
                   : component_executor_(component_executor)
     {}
 

--- a/connectors/dds4ccm/tests/port_status_listener/sample_lost/receiver/psl_sample_lost_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/port_status_listener/sample_lost/receiver/psl_sample_lost_receiver_exec.cpp
@@ -24,7 +24,7 @@ namespace PSL_SampleLostTest_Receiver_Impl
   : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::PSL_SampleLostTest::CCM_Receiver>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::PSL_SampleLostTest::CCM_Receiver>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/tests/apc/async-event-combi/components/sender/async_event_sender_exec.cpp
+++ b/tests/apc/async-event-combi/components/sender/async_event_sender_exec.cpp
@@ -26,7 +26,7 @@ namespace Hello_Sender_Impl
          : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits< ::Hello::CCM_Sender>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits< ::Hello::CCM_Sender>::weak_ref_type component_executor)
     : component_executor_(component_executor)
     {}
 

--- a/tests/gen_test/connector_r/gen_test_connr_exec.cpp
+++ b/tests/gen_test/connector_r/gen_test_connr_exec.cpp
@@ -27,7 +27,7 @@ namespace Hello_MyBaseEvent_Impl
     : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits<Hello::CCM_MyBaseEvent>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits<Hello::CCM_MyBaseEvent>::weak_ref_type component_executor)
       : component_executor_ (std::move(component_executor))
     {
     }

--- a/tests/gen_test_simple/connector_r/gen_test_connr_exec.cpp
+++ b/tests/gen_test_simple/connector_r/gen_test_connr_exec.cpp
@@ -27,7 +27,7 @@ namespace Hello_MyBaseEvent_Impl
     : public IDL::traits<CCM_TT::TT_Handler>::base_type
   {
   public:
-    TT_Callback (IDL::traits<Hello::CCM_MyBaseEvent>::weak_ref_type component_executor)
+    explicit TT_Callback (IDL::traits<Hello::CCM_MyBaseEvent>::weak_ref_type component_executor)
       : component_executor_ (std::move(component_executor))
     {
     }


### PR DESCRIPTION
    * connectors/dds4ccm/examples/custom/src/sender/custom_example_sender_exec.cpp:
    * connectors/dds4ccm/examples/idl/sender/idl_example_sender_exec.cpp:
    * connectors/dds4ccm/examples/shapes_asm/shapes_control_comp/src/shapes_control_comp_exec.cpp:
    * connectors/dds4ccm/tests/apc/gen_comp/components/publisher/publisher_exec.cpp:
    * connectors/dds4ccm/tests/coherent_write/receiver/coherent_writer_receiver_exec.cpp:
    * connectors/dds4ccm/tests/common/ticker_t.h:
    * connectors/dds4ccm/tests/connector_status_listener/components/receiver/csl_receiver_exec.cpp:
    * connectors/dds4ccm/tests/connector_status_listener/components/sender/csl_sender_exec.cpp:
    * connectors/dds4ccm/tests/filters/filter_attrib/read_get/receiver/fa_rg_receiver_exec.cpp:
    * connectors/dds4ccm/tests/filters/query_attrib/read_get/receiver/qa_rg_receiver_exec.cpp:
    * connectors/dds4ccm/tests/late_binded/read_get/receiver/rg_late_bind_receiver_exec.cpp:
    * connectors/dds4ccm/tests/max_delivered_data/getter/receiver/mdd_getter_receiver_exec.cpp:
    * connectors/dds4ccm/tests/max_delivered_data/getter/sender/mdd_sender_exec.cpp:
    * connectors/dds4ccm/tests/max_delivered_data/listeners/data/sender/mdd_sender_exec.cpp:
    * connectors/dds4ccm/tests/max_delivered_data/listeners/state/sender/mdd_sender_exec.cpp:
    * connectors/dds4ccm/tests/port_status_listener/deadline_missed/receiver/psl_deadline_receiver_exec.cpp:
    * connectors/dds4ccm/tests/port_status_listener/deadline_missed/sender/psl_deadline_sender_exec.cpp:
    * connectors/dds4ccm/tests/port_status_listener/sample_lost/receiver/psl_sample_lost_receiver_exec.cpp:
    * tests/apc/async-event-combi/components/sender/async_event_sender_exec.cpp:
    * tests/gen_test/connector_r/gen_test_connr_exec.cpp:
    * tests/gen_test_simple/connector_r/gen_test_connr_exec.cpp: