### PR TITLE
psdd4ccm is now part of axcioma so removed the optional keywords

### DIFF
--- a/connectors/psdd4ccm/docs/src/getting_started.asc
+++ b/connectors/psdd4ccm/docs/src/getting_started.asc
@@ -1,1 +1,0 @@
-** <<{xref_docs_root}/psdd4ccm/psdd4ccm.adoc#,PSDD4CCM>> delivering _Publish and Subscribe Data Distribution_ interaction

--- a/docs/src/getting_started.adoc
+++ b/docs/src/getting_started.adoc
@@ -21,7 +21,7 @@ providing support for:
 ** <<{xref_docs_root}/corba4ccm/corba4ccm.adoc#,CORBA4CCM>> delivering synchronous _Request/Reply_ interaction
 ** <<{xref_docs_root}/ami4ccm/ami4ccm.adoc#,AMI4CCM>> delivering asynchronous _Request/Reply_ interaction
 ** <<{xref_docs_root}/dds4ccm/dds4ccm.adoc#,DDS4CCM>> delivering _State and Event_ interaction
-include::{ciaox11_src_root}/connectors/psdd4ccm/docs/src/getting_started.asc[opts=optional]
+** <<{xref_docs_root}/psdd4ccm/psdd4ccm.adoc#,PSDD4CCM>> delivering _Publish and Subscribe Data Distribution_ interaction
 ** <<{xref_docs_root}/tt4ccm/tt4ccm.adoc#,TT4CCM>> delivering _Timed Trigger_ interaction
 include::{ciaox11_src_root}/exf/docs/src/getting_started.asc[opts=optional]
 * <<{xref_docs_root}/ddsx11/ddsx11.adoc#,DDSX11>> provides the

--- a/docs/src/lib_mpc.adoc
+++ b/docs/src/lib_mpc.adoc
@@ -35,4 +35,4 @@ include::{ciaox11_src_root}/connectors/dds4ccm/docs/src/lib_mpc.asc[]
 
 include::{ciaox11_src_root}/connectors/tt4ccm/docs/src/lib_mpc.asc[]
 
-include::{ciaox11_src_root}/connectors/psdd4ccm/docs/src/lib_mpc.asc[opts=optional]
+include::{ciaox11_src_root}/connectors/psdd4ccm/docs/src/lib_mpc.asc[]

--- a/docs/src/ridlc.adoc
+++ b/docs/src/ridlc.adoc
@@ -121,6 +121,6 @@ include::{ciaox11_src_root}/ddsx11/docs/src/ridlc.asc[]
 
 include::{ciaox11_src_root}/connectors/dds4ccm/docs/src/ridlc.asc[]
 
-include::{ciaox11_src_root}/connectors/psdd4ccm/docs/src/ridlc.asc[opts=optional]
+include::{ciaox11_src_root}/connectors/psdd4ccm/docs/src/ridlc.asc[]
 
 include::{ciaox11_src_root}/exf/docs/src/ridlc.asc[opts=optional]


### PR DESCRIPTION
    * connectors/psdd4ccm/docs/src/getting_started.asc:
      Deleted.

    * docs/src/getting_started.adoc:
    * docs/src/lib_mpc.adoc:
    * docs/src/ridlc.adoc: