### PR TITLE
Minor layout and uniform initialization changes

### DIFF
--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb
@@ -15,8 +15,7 @@ namespace PSDD
                             <%= scoped_cxxtype %>::value_type,
                             <%= cxxdim_sizes.first %>>
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::false_type key_only;
     typedef std::true_type no_key;

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb
@@ -6,8 +6,7 @@ namespace PSDD
   struct traits< <%= scoped_cxxtype %>>
     : public common_traits< <%= scoped_cxxtype %>>
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::true_type key_only;
     typedef std::false_type no_key;
@@ -34,7 +33,7 @@ namespace PSDD
         IDL::traits<PSDataIn>::ref_type& d,
         <%= scoped_cxx_out_type %> datum)
     {
-      uint32_t ev;
+      uint32_t ev {};
       if (::PSDD::traits<uint32_t>::extract_key (d, ev))
       {
         datum = static_cast< <%= scoped_cxxtype %>> (ev);
@@ -52,7 +51,7 @@ namespace PSDD
       if (provides_key)
         return true;
 
-      uint32_t ev;
+      uint32_t ev {};
       if (::PSDD::traits<uint32_t>::extract_data (d, ev, false))
       {
         datum = static_cast< <%= scoped_cxxtype %>> (ev);

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb
@@ -13,8 +13,7 @@ namespace PSDD
     : public common_traits< <%= scoped_cxxtype %>>
     , public sequence_packing< <%= scoped_element_cxxtype %><% if is_bounded? %>, <%= bound %>U<% end %>>
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::false_type key_only;
     typedef std::true_type no_key;

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb
@@ -17,8 +17,7 @@ namespace PSDD
     , public string_packing<<%= bound %>>
 % end
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::true_type key_only;
     typedef std::false_type no_key;

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb
@@ -6,8 +6,7 @@ namespace PSDD
   struct traits< <%= scoped_cxxtype %>>
     : public common_traits< <%= scoped_cxxtype %>>
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::<%= has_key_only? %>_type key_only;
     typedef std::<%= has_no_key? %>_type no_key;

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb
@@ -6,8 +6,7 @@ namespace PSDD
   struct traits< <%= scoped_cxxtype %>>
     : public common_traits< <%= scoped_cxxtype %>>
   {
-    static
-    std::string get_type_name () { return "<%= scoped_cxxname %>"; }
+    static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
     typedef std::false_type key_only;
     typedef std::false_type no_key;
@@ -100,7 +99,7 @@ namespace PSDD
         <%= scoped_cxx_out_type %> datum,
         bool provides_key)
     {
-      <%= scoped_switch_cxxtype %> tmp_disc = datum._d ();
+      <%= scoped_switch_cxxtype %> tmp_disc { datum._d () };
       if (provides_key || ::PSDD::traits< <%= scoped_switch_cxxtype %>>::extract_data (d, tmp_disc, false))
       {
         switch (tmp_disc)


### PR DESCRIPTION
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb: