### PR TITLE
Changed the register of the proxy operations to return bool in order …

### DIFF
--- a/brix/ciaox11/apc/mpcprojects/mpc_idl.rb
+++ b/brix/ciaox11/apc/mpcprojects/mpc_idl.rb
@@ -170,7 +170,6 @@ module AxciomaPC
       end
 
       # Methods for MPC project file generation
-
       def mpc_genobj
         unless @mpc_genobj
           idlflags = idl_flags.add_flags.dup

--- a/ddsx11/dds/dds_data_reader_listener.h
+++ b/ddsx11/dds/dds_data_reader_listener.h
@@ -68,7 +68,7 @@ namespace DDSX11
     IDL::traits< ::DDS::DataReaderListener>::ref_type impl_;
 
     // In order to gain performance (especially for on_data_available), we keep
-    // a weak_ref_pointer to the data reader. This pointer will be set the first
+    // a weak_ref_pointer to the datareader. This pointer will be set the first
     // time a callback from DDS comes in. The pointer will be converted to a strong
     // reference and checked on each callback.
     // This prevents looking up the internal map in the ProxyEntityManager each

--- a/ddsx11/dds/dds_data_reader_t.cpp
+++ b/ddsx11/dds/dds_data_reader_t.cpp
@@ -852,9 +852,10 @@ namespace DDSX11
         this->native_entity ()->get_qos (qos_in.value_));
     if (retcode != ::DDS::RETCODE_OK)
       {
-        DDSX11_IMPL_LOG_ERROR (
-          "DataReader_T<NATIVE_TYPED_READER, TYPED_READER_TYPE, TOPIC_TYPE, SEQ_TYPE, NATIVE_SEQ_TYPE>::set_qos - "
-          "Error: Unable to retrieve QoS.");
+        DDSX11_IMPL_LOG_ERROR ("DataReader_T<NATIVE_TYPED_READER, TYPED_READER_TYPE, TOPIC_TYPE, SEQ_TYPE, NATIVE_SEQ_TYPE>::set_qos - "
+          << "Error: Unable to retrieve QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/dds/dds_data_writer_t.cpp
+++ b/ddsx11/dds/dds_data_writer_t.cpp
@@ -38,9 +38,10 @@ namespace DDSX11
         this->native_entity ()->get_qos (qos_in.value_));
     if (retcode != ::DDS::RETCODE_OK)
       {
-        DDSX11_IMPL_LOG_ERROR (
-          "DataWriter_T<TOPIC_TYPE, NATIVE_TYPED_WRITER, TYPED_WRITER_TYPE>::set_qos - "
-          "Error: Unable to retrieve QoS.");
+        DDSX11_IMPL_LOG_ERROR ("DataWriter_T<TOPIC_TYPE, NATIVE_TYPED_WRITER, TYPED_WRITER_TYPE>::set_qos - "
+          << "Error: Unable to retrieve QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/dds/dds_domain_participant.cpp
+++ b/ddsx11/dds/dds_domain_participant.cpp
@@ -97,10 +97,18 @@ namespace DDSX11
 
     if (publisher)
       {
-        DDS_ProxyEntityManager::register_publisher_proxy (publisher);
+        if (DDS_ProxyEntityManager::register_publisher_proxy (publisher))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_publisher - "
+              << "Successfully created and registered a publisher.");
+          }
+        else
+          {
+            publisher = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_publisher - "
-          << "Successfully created a Publisher.");
+            DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_publisher - "
+              << "ERROR: Failed to register a publisher proxy.");
+          }
       }
     else
       {
@@ -216,10 +224,18 @@ namespace DDSX11
     if (subscriber)
       {
         // Register the fresh created proxy in the proxy entity manager
-        DDS_ProxyEntityManager::register_subscriber_proxy (subscriber);
+        if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_subscriber - "
+              << "Successfully created and registered a subscriber.");
+          }
+        else
+          {
+            subscriber = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_subscriber - "
-          << "Successfully created a Subscriber.");
+            DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_subscriber - "
+              << "ERROR: Failed to register a subscriber proxy.");
+          }
       }
     else
       {
@@ -384,10 +400,18 @@ namespace DDSX11
 
     if (topic_reference)
       {
-        DDS_ProxyEntityManager::register_topic_proxy (topic_reference);
+        if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_topic - "
+              << "Successfully created and registered a Topic.");
+          }
+        else
+          {
+            topic_reference = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_topic - "
-          << "Successfully created a Topic.");
+            DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_topic - "
+              << "ERROR: Failed to register a topic proxy.");
+          }
       }
     else
       {

--- a/ddsx11/dds/dds_domain_participant.cpp
+++ b/ddsx11/dds/dds_domain_participant.cpp
@@ -53,7 +53,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_publisher - "
-          << "Error: Unable to retrieve default publisher qos: <"
+          << "Error: Unable to retrieve default publisher qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return {};
@@ -147,7 +147,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_publisher - "
-          << "Error: delete_publisher returned non-ok error code <"
+          << "Error: delete_publisher returned non-ok error <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
       }
@@ -179,7 +179,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_subscriber - "
-          << "Error: Unable to retrieve default subscriber qos."
+          << "Error: Unable to retrieve default subscriber qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return {};
@@ -276,7 +276,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_subscriber - "
-          << "Error: delete_subscriber returned non-ok error code <"
+          << "Error: delete_subscriber returned non-ok error <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
       }
@@ -351,7 +351,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::create_topic - "
-          << "Error: Unable to retrieve default topic qos: <"
+          << "Error: Unable to retrieve default topic qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return {};
@@ -446,10 +446,18 @@ namespace DDSX11
       ::DDSX11::traits< ::DDS::ReturnCode_t>::retn (
         this->native_entity ()->delete_topic (top));
 
-    DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::delete_topic - "
-      << "delete_topic returned error code <"
-      << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
-      << ">");
+    if (retcode != ::DDS::RETCODE_OK)
+      {
+        DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_topic - "
+          << "Error: delete_topic returned non-ok error code <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
+      }
+    else
+      {
+        DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::delete_topic - "
+          << "Provided topic successfully deleted");
+      }
 
     return retcode;
   }
@@ -610,7 +618,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_qos - "
-          << "Error: Unable to retrieve participant qos: <"
+          << "Error: Unable to retrieve participant qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return retcode;
@@ -766,7 +774,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_default_publisher_qos - "
-          << "Error: Unable to retrieve default publisher qos: <"
+          << "Error: Unable to retrieve default publisher qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return retcode;
@@ -810,7 +818,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_default_subscriber_qos - "
-          << "Error: Unable to retrieve default subscriber qos: <"
+          << "Error: Unable to retrieve default subscriber qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return retcode;
@@ -854,7 +862,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_default_topic_qos - "
-          << "Error: Unable to retrieve default topic qos: <"
+          << "Error: Unable to retrieve default topic qos <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
         return retcode;

--- a/ddsx11/dds/dds_domain_participant_factory.cpp
+++ b/ddsx11/dds/dds_domain_participant_factory.cpp
@@ -46,7 +46,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipantFactory_proxy::create_participant - "
-          << "Error: Unable to retrieve default participant qos.");
+          << "Error: Unable to retrieve default participant QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return {};
       }
 #endif
@@ -143,7 +145,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipantFactory_proxy::delete_participant - "
-          << "delete_participant returned non-ok error code <"
+          << "delete_participant returned non-ok error <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
       }
@@ -203,7 +205,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipantFactory_proxy::set_default_participant_qos - "
-          << "Error: Unable to retrieve default participant qos");
+          << "Error: Unable to retrieve default participant QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif
@@ -244,7 +248,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_qos - "
-          << "Error: Unable to retrieve participant factory qos.");
+          << "Error: Unable to retrieve domain participant factory QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/dds/dds_domain_participant_factory.cpp
+++ b/ddsx11/dds/dds_domain_participant_factory.cpp
@@ -85,16 +85,24 @@ namespace DDSX11
     // of scope.
     listener_guard.release ();
 
-    IDL::traits< ::DDS::DomainParticipant>::ref_type retval =
+    IDL::traits< ::DDS::DomainParticipant>::ref_type domain_participant =
       VendorUtils::create_domain_participant_proxy (dds_dp);
 
-    if (retval)
+    if (domain_participant)
       {
-        DDS_ProxyEntityManager::register_dp_proxy (retval);
+        if (DDS_ProxyEntityManager::register_dp_proxy (domain_participant))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipantFactory_proxy::create_participant - "
+              << "Successfully created and registered a DomainParticipant for domain <"
+              << domain_id << ">");
+          }
+        else
+          {
+            domain_participant = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipantFactory_proxy::create_participant - "
-          << "Successfully created a DomainParticipant for domain <"
-          << domain_id << ">");
+            DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipantFactory_proxy::create_participant - "
+              << "ERROR: Failed to register a domain participant proxy.");
+          }
       }
     else
       {
@@ -103,7 +111,7 @@ namespace DDSX11
           << domain_id << ">");
       }
 
-    return retval;
+    return domain_participant;
   }
 
 

--- a/ddsx11/dds/dds_proxy_entity_manager.cpp
+++ b/ddsx11/dds/dds_proxy_entity_manager.cpp
@@ -27,7 +27,7 @@ namespace DDSX11
   std::mutex DDS_ProxyEntityManager::dp_mutex;
 
   template<typename PROXY_TYPE, typename PROXY_MAP>
-  void
+  bool
   DDS_ProxyEntityManager::register_proxy (
     PROXY_TYPE proxy,
     PROXY_MAP &lst)
@@ -39,10 +39,13 @@ namespace DDSX11
     {
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::register_proxy - "
         "Registering proxy <" << proxy->get_instance_handle () << "> failed");
-      proxy = nullptr;
+      return false;
     }
+
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_proxy - "
-      "Registered proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << "> succeeded");
+
+    return true;
   }
 
   template<typename PROXY_TYPE, typename PROXY_MAP>
@@ -88,7 +91,6 @@ namespace DDSX11
     if (it != lst.end ())
     {
       lst.erase (it);
-      proxy = nullptr;
       DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_proxy - "
         << "Removed proxy with handle <" << handle
         << "> from the list");
@@ -101,7 +103,7 @@ namespace DDSX11
     }
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_datareader_proxy (
     ::IDL::traits< ::DDS::DataReader>::ref_type proxy)
   {
@@ -116,7 +118,7 @@ namespace DDSX11
         (proxy, DDS_ProxyEntityManager::dr_proxies);
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_datawriter_proxy (
     ::IDL::traits< ::DDS::DataWriter>::ref_type proxy)
   {
@@ -131,7 +133,7 @@ namespace DDSX11
         (proxy, DDS_ProxyEntityManager::dw_proxies);
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_subscriber_proxy (
     ::IDL::traits< ::DDS::Subscriber>::ref_type proxy)
   {
@@ -146,7 +148,7 @@ namespace DDSX11
         (proxy, DDS_ProxyEntityManager::sub_proxies);
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_publisher_proxy (
     ::IDL::traits< ::DDS::Publisher>::ref_type proxy)
   {
@@ -161,7 +163,7 @@ namespace DDSX11
         (proxy, DDS_ProxyEntityManager::pub_proxies);
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_topic_proxy (
     ::IDL::traits< ::DDS::Topic>::ref_type proxy)
   {
@@ -176,7 +178,7 @@ namespace DDSX11
         (proxy, DDS_ProxyEntityManager::tp_proxies);
   }
 
-  void
+  bool
   DDS_ProxyEntityManager::register_dp_proxy (
     ::IDL::traits< ::DDS::DomainParticipant>::ref_type proxy)
   {

--- a/ddsx11/dds/dds_proxy_entity_manager.h
+++ b/ddsx11/dds/dds_proxy_entity_manager.h
@@ -61,35 +61,25 @@ namespace DDSX11
     ~DDS_ProxyEntityManager () = default;
 
     /**
-      * @name          register_xxx_proxy
-      * @brief         Storing the given proxy into the corresponding map
-      * @param proxy   The C++11 proxy to store. Will be set to a nullptr
-      *                if registration fails.
+      * @name         register_xxx_proxy
+      * @brief        Storing the given proxy into the corresponding map
+      * @param proxy  The C++11 proxy to store
+      * @retval true  Registering the proxy succeeded
+      * @retval false Registering the proxy failed
       */
     //@{
-    static void
-    register_datareader_proxy (
-      ::IDL::traits< ::DDS::DataReader>::ref_type proxy);
+    static bool
+    register_datareader_proxy (::IDL::traits< ::DDS::DataReader>::ref_type proxy);
 
-    static void
-    register_datawriter_proxy (
-      ::IDL::traits< ::DDS::DataWriter>::ref_type proxy);
+    static bool register_datawriter_proxy (::IDL::traits< ::DDS::DataWriter>::ref_type proxy);
 
-    static void
-    register_subscriber_proxy (
-      ::IDL::traits< ::DDS::Subscriber>::ref_type proxy);
+    static bool register_subscriber_proxy (::IDL::traits< ::DDS::Subscriber>::ref_type proxy);
 
-    static void
-    register_publisher_proxy (
-      ::IDL::traits< ::DDS::Publisher>::ref_type proxy);
+    static bool register_publisher_proxy (::IDL::traits< ::DDS::Publisher>::ref_type proxy);
 
-    static void
-    register_topic_proxy (
-      ::IDL::traits< ::DDS::Topic>::ref_type proxy);
+    static bool register_topic_proxy (::IDL::traits< ::DDS::Topic>::ref_type proxy);
 
-    static void
-    register_dp_proxy (
-      ::IDL::traits< ::DDS::DomainParticipant>::ref_type proxy);
+    static bool register_dp_proxy (::IDL::traits< ::DDS::DomainParticipant>::ref_type proxy);
     //@}
 
     /**
@@ -97,8 +87,6 @@ namespace DDSX11
       * @brief         Looking up the given proxy and remove it from
       *                the corresponding map
       * @param proxy   The C++11 proxy to unregister
-      * @return        The pointer to the native entity if ok, nullptr if an
-      *                error occurred.
       */
     //@{
     static void
@@ -171,15 +159,16 @@ namespace DDSX11
       * @name          register_proxy
       * @brief         Helper method, preventing double code.
       *                Stores the C++11 proxy in the given map in a consistent way.
-      * @tparam ENTITY_TYPE The type of entity to store (DataReader/DataWRiter/Topic/...)
-      * @tparam PROXY_MAP   The type of the map in which to store the given proxy
-      * @param  proxy   The C++11 proxy to store. Will be set to a nullptr is registration
-      *                 fails.
-      * @param  lst     reference to the map in which to store the proxy.
+      * @tparam PROXY_TYPE The type of entity to unregister (DataReader/DataWRiter/Topic/...)
+      * @tparam PROXY_MAP  The type of the map in which to store the given proxy
+      * @param  proxy   The C++11 proxy to store
+      * @param  lst     Reference to the map in which to store the proxy
+      * @retval true    The registering of the proxy succeeded
+      * @retval false   The registering of the proxy failed
       *
       */
     template<typename PROXY_TYPE, typename PROXY_MAP>
-    static void
+    static bool
     register_proxy (
       PROXY_TYPE proxy,
       PROXY_MAP &lst);
@@ -188,11 +177,11 @@ namespace DDSX11
       * @name          get_proxy
       * @brief         Helper method, preventing double code.
       *                Retrieves the C++11 proxy in the given map in a consistent way.
-      * @tparam ENTITY_TYPE The type of entity to return (DataReader/DataWRiter/Topic/...)
-      * @tparam PROXY_MAP   The type of the map from which to retrieve the given proxy
+      * @tparam PROXY_TYPE The type of entity to unregister (DataReader/DataWRiter/Topic/...)
+      * @tparam PROXY_MAP  The type of the map from which to retrieve the given proxy
       * @param  native_entity The native pointer to the entity
-      * @param  lst     reference to the map in which to store the proxy.
-      * @return        The C++11 proxies if found in the map, a nullptr if not found
+      * @param  lst     Reference to the map in which to store the proxy.
+      * @return         The C++11 proxies if found in the map, a nullptr if not found
       *
       */
     template<typename PROXY_TYPE, typename PROXY_MAP>
@@ -204,13 +193,11 @@ namespace DDSX11
     /**
       * @name          unregister_proxy
       * @brief         Helper method, preventing double code.
-      *                Removes the given proxy from the corresponding list and
-      *                sets it to a nullptr.
-      * @tparam ENTITY_TYPE The type of entity to unregister (DataReader/DataWRiter/Topic/...)
-      * @tparam PROXY_MAP   The type of the map from which to unregister the given proxy
+      *                Removes the given proxy from the corresponding list.
+      * @tparam PROXY_TYPE The type of entity to unregister (DataReader/DataWRiter/Topic/...)
+      * @tparam PROXY_MAP  The type of the map from which to unregister the given proxy
       * @param  proxy   The C++11 proxy to unregister
-      * @param  lst     reference to the map from which to unregister the proxy.
-      *
+      * @param  lst     Reference to the map from which to unregister the proxy
       */
     template<typename PROXY_TYPE, typename PROXY_MAP>
     static void
@@ -218,32 +205,32 @@ namespace DDSX11
       PROXY_TYPE proxy,
       PROXY_MAP &lst);
 
-    /// Place holder for DataReader C++11 proxies
+    /// Map containing all DataReader C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DataReader>::ref_type, CompareHandles> DataReaderProxies;
     static DataReaderProxies dr_proxies;
     static std::mutex dr_mutex;
 
-    /// Place holder for DataWriter C++11 proxies
+    /// Map containing all DataWriter C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DataWriter>::ref_type, CompareHandles> DataWriterProxies;
     static DataWriterProxies dw_proxies;
     static std::mutex dw_mutex;
 
-    /// Place holder for Subscriber C++11 proxies
+    /// Map containing all Subscriber C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::Subscriber>::ref_type, CompareHandles> SubscriberProxies;
     static SubscriberProxies sub_proxies;
     static std::mutex sub_mutex;
 
-    /// Place holder for Publisher C++11 proxies
+    /// Map containing all Publisher C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::Publisher>::ref_type, CompareHandles> PublisherProxies;
     static PublisherProxies pub_proxies;
     static std::mutex pub_mutex;
 
-    /// Place holder for Topic C++11 proxies
+    /// Map containing all Topic C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::Topic>::ref_type, CompareHandles> TopicProxies;
     static TopicProxies tp_proxies;
     static std::mutex tp_mutex;
 
-    /// Place holder for Participant C++11 proxies
+    /// Map containing all DomainParticipant C++11 proxies
     typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DomainParticipant>::ref_type, CompareHandles> DomainParticipantProxies;
     static DomainParticipantProxies dp_proxies;
     static std::mutex dp_mutex;

--- a/ddsx11/dds/dds_publisher.cpp
+++ b/ddsx11/dds/dds_publisher.cpp
@@ -48,7 +48,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::create_datawriter - "
-          << "Error: Unable to retrieve default datawriter qos.");
+          << "Error: Unable to retrieve default datawriter QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return nullptr;
       }
 #endif
@@ -150,7 +152,7 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_i::delete_datawriter - "
-          << "Error: Native delete_datawriter returned non-ok error code <"
+          << "Error: Native delete_datawriter returned non-ok error <"
           << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
           << ">");
       }
@@ -202,7 +204,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::set_qos - "
-          << "Error: Unable to retrieve publisher qos.");
+          << "Error: Unable to retrieve publisher QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif
@@ -352,7 +356,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::set_default_datawriter_qos - "
-          << "Error: Unable to retrieve default datawriter qos.");
+          << "Error: Unable to retrieve default datawriter <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/dds/dds_publisher.cpp
+++ b/ddsx11/dds/dds_publisher.cpp
@@ -93,10 +93,18 @@ namespace DDSX11
                                             native_dw);
     if (datawriter)
     {
-      DDS_ProxyEntityManager::register_datawriter_proxy (datawriter);
+      if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter))
+        {
+          DDSX11_IMPL_LOG_DEBUG ("DDS_Publisher_proxy::create_datawriter - "
+            << "Successfully created and registered a DataWriter");
+        }
+      else
+        {
+          datawriter = nullptr;
 
-      DDSX11_IMPL_LOG_DEBUG ("DDS_Publisher_proxy::create_datawriter - "
-        << "Successfully created a DataWriter");
+          DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::create_datawriter - "
+            << "ERROR: Failed to register a datawriter proxy.");
+        }
     }
     else
     {

--- a/ddsx11/dds/dds_subscriber.cpp
+++ b/ddsx11/dds/dds_subscriber.cpp
@@ -80,7 +80,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Subscriber_proxy::create_native_datareader - "
-          << "Error: Unable to retrieve default datareader qos.");
+          << "Error: Unable to retrieve default datareader qos <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return nullptr;
       }
 #endif
@@ -115,7 +117,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Subscriber_proxy::create_native_datareader - "
-          << "Error: Unable to retrieve default datareader qos.");
+          << "Error: Unable to retrieve default datareader qos <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return nullptr;
       }
 #endif
@@ -366,7 +370,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Subscriber_proxy::set_qos - "
-          << "Error: Unable to retrieve subscriber qos.");
+          << "Error: Unable to retrieve subscriber qos <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif
@@ -483,7 +489,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Subscriber_proxy::set_default_datareader_qos - "
-          << "Error: Unable to retrieve default datareader qos.");
+          << "Error: Unable to retrieve default datareader qos <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/dds/dds_subscriber.cpp
+++ b/ddsx11/dds/dds_subscriber.cpp
@@ -193,7 +193,7 @@ namespace DDSX11
     DDSX11_IMPL_LOG_DEBUG ("DDS_Subscriber_proxy::create_datareader - "
       << "Successfully created native datareader");
 
-    // Create the X11 typed data reader
+    // Create the X11 typed datareader
     IDL::traits< ::DDS::DataReader>::ref_type datareader =
       DDS_TypeSupport_i::create_datareader (
             this->get_participant (),
@@ -203,15 +203,23 @@ namespace DDSX11
     if (datareader)
       {
         // Register the fresh created proxy in the proxy entity manager
-        DDS_ProxyEntityManager::register_datareader_proxy (datareader);
+        if (DDS_ProxyEntityManager::register_datareader_proxy (datareader))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("DDS_Subscriber_proxy::create_datareader - "
+              << "Successfully created and registered a datareader.");
+          }
+        else
+          {
+            datareader = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("DDS_Subscriber_proxy::create_datareader - "
-          << "Successfully created a data reader.");
+            DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::create_datareader - "
+              << "ERROR: Failed to register a datareader proxy.");
+          }
       }
     else
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_Subscriber_proxy::create_datareader - "
-          << "ERROR: Failed to create a data reader.");
+          << "ERROR: Failed to create a datareader.");
       }
 
     return datareader;

--- a/ddsx11/dds/dds_topic.cpp
+++ b/ddsx11/dds/dds_topic.cpp
@@ -40,7 +40,9 @@ namespace DDSX11
     if (retcode != ::DDS::RETCODE_OK)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::set_qos - "
-          << "Error: Unable to retrieve participant qos.");
+          << "Error: Unable to retrieve participant QoS <"
+          << IDL::traits< ::DDS::ReturnCode_t>::write<retcode_formatter> (retcode)
+          << ">");
         return retcode;
       }
 #endif

--- a/ddsx11/vendors/ndds/dds/ndds_domain_participant.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_domain_participant.cpp
@@ -82,10 +82,18 @@ namespace DDSX11
 
       if (publisher)
         {
-          DDS_ProxyEntityManager::register_publisher_proxy (publisher);
+          if (DDS_ProxyEntityManager::register_publisher_proxy (publisher))
+            {
+              DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_publisher_with_profile <"
+                << qos_profile << "> - Successfully created and registered a Publisher.");
+            }
+          else
+            {
+              publisher = nullptr;
 
-          DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_publisher_with_profile <"
-            << qos_profile << "> - Successfully created a Publisher.");
+              DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_publisher_with_profile - "
+                << "ERROR: Failed to register a publisher proxy.");
+            }
         }
       else
         {
@@ -146,15 +154,23 @@ namespace DDSX11
       if (subscriber)
         {
           // Register the fresh created proxy in the proxy entity manager
-          DDS_ProxyEntityManager::register_subscriber_proxy (subscriber);
+          if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber))
+            {
+              DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_subscriber_with_profile <"
+                << qos_profile << "> - Successfully created and registered a subscriber.");
+            }
+          else
+            {
+              subscriber = nullptr;
 
-          DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_subscriber_with_profile <"
-            << qos_profile << "> - Successfully created a Subscriber.");
+              DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_subscriber_with_profile - "
+                << "ERROR: Failed to register a subscriber proxy.");
+            }
         }
       else
         {
           DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_subscriber_with_profile <"
-            << qos_profile << "> - ERROR: Failed to create a Subscriber.");
+            << qos_profile << "> - ERROR: Failed to create a subscriber.");
         }
 
       return subscriber;
@@ -225,20 +241,30 @@ namespace DDSX11
       // of scope.
       ccm_dds_tl.release ();
 
-      IDL::traits< ::DDS::Topic>::ref_type retval =
+      IDL::traits< ::DDS::Topic>::ref_type topic_reference =
         CORBA::make_reference<DDSX11::DDS_Topic_proxy>(dds_tp);
-      DDS_ProxyEntityManager::register_topic_proxy (retval);
-      if (retval)
+
+      if (topic_reference)
         {
-          DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_topic_with_profile <"
-            << qos_profile << "> - Successfully created a Topic.");
+          if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference))
+            {
+              DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_topic_with_profile - "
+                << "Successfully created and registered a topic.");
+            }
+          else
+            {
+              topic_reference = nullptr;
+
+              DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_topic_with_profile - "
+                << "ERROR: Failed to register a topic proxy.");
+            }
         }
       else
         {
           DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_topic_with_profile <"
-            << qos_profile << "> - ERROR: Failed to create a Topic.");
+            << qos_profile << "> - ERROR: Failed to create a topic.");
         }
-      return retval;
+      return topic_reference;
     }
   }
 }

--- a/ddsx11/vendors/ndds/dds/ndds_domain_participant_factory.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_domain_participant_factory.cpp
@@ -91,11 +91,20 @@ namespace DDSX11
       if (retval)
         {
           // Register the fresh created proxy in the proxy entity manager
-          DDS_ProxyEntityManager::register_dp_proxy (retval);
+          if (DDS_ProxyEntityManager::register_dp_proxy (retval))
+            {
+              DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipantFactory_proxy::create_participant_with_profile <"
+                << qos_profile << "> - Successfully created and registered a DomainParticipant "
+                << "for domain <" << domain_id << ">");
+            }
+          else
+            {
+              retval = nullptr;
 
-          DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipantFactory_proxy::create_participant_with_profile <"
-            << qos_profile << "> - Successfully created a DomainParticipant "
-            << "for domain <" << domain_id << ">");
+              DDSX11_IMPL_LOG_ERROR ("NDDS_DomainParticipant_proxy::create_participant_with_profile - "
+                << "ERROR: Failed to register a domainparticipant proxy.");
+            }
+
         }
       else
         {

--- a/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
@@ -85,11 +85,19 @@ namespace DDSX11
 
       if (datawriter)
       {
-        DDS_ProxyEntityManager::register_datawriter_proxy (datawriter);
+        if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter))
+        {
+          DDSX11_IMPL_LOG_DEBUG ("NDDS_Publisher_proxy::create_datawriter_with_profile - "
+            << "Successfully created and registered a datawriter with profile <"
+            << qos_profile << ">");
+        }
+        else
+        {
+          datawriter = nullptr;
 
-        DDSX11_IMPL_LOG_DEBUG ("NDDS_Publisher_proxy::create_datawriter_with_profile - "
-          << "Successfully created a dataWriter with profile <"
-          << qos_profile << ">");
+          DDSX11_IMPL_LOG_ERROR ("DDS_Publisher_proxy::create_datawriter - "
+            << "ERROR: Failed to register a datawriter proxy.");
+        }
       }
       else
       {

--- a/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
@@ -148,10 +148,19 @@ namespace DDSX11
       if (datareader)
         {
           // Register the fresh created proxy in the proxy entity manager
-          DDS_ProxyEntityManager::register_datareader_proxy (datareader);
+          if (DDS_ProxyEntityManager::register_datareader_proxy (datareader))
+          {
+            DDSX11_IMPL_LOG_DEBUG ("NDDS_Subscriber_proxy::create_datareader_with_profile - "
+              << "Successfully created and registered a datareader with profile <"
+              << qos_profile << ">");
+          }
+          else
+          {
+            datareader = nullptr;
 
-          DDSX11_IMPL_LOG_DEBUG ("NDDS_Subscriber_proxy::create_datareader_with_profile - "
-            << "Successfully created a data reader.");
+            DDSX11_IMPL_LOG_ERROR ("NDDS_Subscriber_proxy::create_datareader_with_profile - "
+              << "ERROR: Failed to register a datareader proxy.");
+          }
         }
       else
         {


### PR DESCRIPTION
…to log that registering a proxy failed and set the reference we return to nullptr so that the caller knows we have a real problem

    * brix/ciaox11/apc/mpcprojects/mpc_idl.rb:
    * ddsx11/dds/dds_data_reader_listener.h:
    * ddsx11/dds/dds_domain_participant.cpp:
    * ddsx11/dds/dds_domain_participant_factory.cpp:
    * ddsx11/dds/dds_proxy_entity_manager.cpp:
    * ddsx11/dds/dds_proxy_entity_manager.h:
    * ddsx11/dds/dds_publisher.cpp:
    * ddsx11/dds/dds_subscriber.cpp:
    * ddsx11/vendors/ndds/dds/ndds_domain_participant.cpp:
    * ddsx11/vendors/ndds/dds/ndds_domain_participant_factory.cpp:
    * ddsx11/vendors/ndds/dds/ndds_publisher.cpp:
    * ddsx11/vendors/ndds/dds/ndds_subscriber.cpp: