### PR TITLE
Removed redundant override

### DIFF
--- a/connectors/dds4ccm/impl/dds4ccm_data_listener_t.h
+++ b/connectors/dds4ccm/impl/dds4ccm_data_listener_t.h
@@ -52,7 +52,7 @@ namespace CIAOX11
         IDL::traits< ::DDS::QueryCondition>::ref_type qc,
         TOPIC_SEQ_TYPE &data,
         ::DDS::SampleInfoSeq &sample_info,
-        int32_t max_samples) override = 0;
+        int32_t max_samples) = 0;
 
       DataReaderListenerBase_T() = delete;
       DataReaderListenerBase_T(const DataReaderListenerBase_T&) = delete;

--- a/connectors/dds4ccm/impl/dds4ccm_state_listener_t.h
+++ b/connectors/dds4ccm/impl/dds4ccm_state_listener_t.h
@@ -51,7 +51,7 @@ namespace CIAOX11
         IDL::traits< ::DDS::QueryCondition>::ref_type qc,
         TOPIC_SEQ_TYPE &data,
         ::DDS::SampleInfoSeq &sample_info,
-        int32_t max_samples) override = 0;
+        int32_t max_samples) = 0;
 
       DataReaderStateListenerBase_T() = delete;
       DataReaderStateListenerBase_T(const DataReaderStateListenerBase_T&) = delete;

--- a/connectors/dds4ccm/tests/log_formatters/main.cpp
+++ b/connectors/dds4ccm/tests/log_formatters/main.cpp
@@ -14,22 +14,22 @@ class MyEntity
   : public IDL::traits<DDS::Entity>::base_type
 {
 public:
-  virtual DDS::ReturnCode_t enable() override
+  DDS::ReturnCode_t enable() override
   {
     return ::DDS::RETCODE_OK;
   }
 
-  virtual IDL::traits<DDS::StatusCondition>::ref_type get_statuscondition() override
+  IDL::traits<DDS::StatusCondition>::ref_type get_statuscondition() override
   {
     return nullptr;
   }
 
-  virtual DDS::StatusMask get_status_changes() override
+  DDS::StatusMask get_status_changes() override
   {
     return DDS::LIVELINESS_LOST_STATUS;
   }
 
-  virtual DDS::InstanceHandle_t get_instance_handle() override
+  DDS::InstanceHandle_t get_instance_handle() override
   {
 #if defined DDSX11_NDDS
     return DDS::InstanceHandle_t {{{15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0}}, 16, false};

--- a/connectors/dds4ccm/tests/type_support/main.cpp
+++ b/connectors/dds4ccm/tests/type_support/main.cpp
@@ -24,11 +24,11 @@ public:
   TestTypeFactory () = default;
   virtual ~TestTypeFactory() {}
 
-  virtual IDL::traits< ::DDS::DataWriter>::ref_type
+  IDL::traits< ::DDS::DataWriter>::ref_type
   create_datawriter (
     ::DDS_Native::DDS::DataWriter* dw) override;
 
-  virtual IDL::traits< ::DDS::DataReader>::ref_type
+  IDL::traits< ::DDS::DataReader>::ref_type
   create_datareader (
     ::DDS_Native::DDS::DataReader* dr) override;
 };

--- a/connectors/psdd4ccm/tests/custom-serializer/serializer/topic_zmq_ser.h
+++ b/connectors/psdd4ccm/tests/custom-serializer/serializer/topic_zmq_ser.h
@@ -24,53 +24,45 @@ namespace Emitter
       virtual ~Custom_ZMQ_Serializer () = default;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::setup_pack
-      virtual
       bool
       setup_pack (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::pack_key
-      virtual
       bool
       pack_key (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data,
           const ::Test::Topic& keyvalue) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::pack_data
-      virtual
       bool
       pack_data (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data,
           const ::Test::Topic& datum) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::finalize_pack
-      virtual
       void
       finalize_pack (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::setup_unpack
-      virtual
       bool
       setup_unpack (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::unpack_key
-      virtual
       bool
       unpack_key (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data,
           ::Test::Topic& keyvalue) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::unpack_data
-      virtual
       bool
       unpack_data (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data,
           ::Test::Topic& datum) override;
 
       /// @copydoc topicPS.idl::LoRa::Topic::Serializer::finalize_unpack
-      virtual
       void
       finalize_unpack (
           IDL::traits< ::CCM_PSDD::PSData>::ref_type data) override;

--- a/ddsx11/dds/dds_publisher_listener.h
+++ b/ddsx11/dds/dds_publisher_listener.h
@@ -25,7 +25,7 @@ namespace DDSX11
       IDL::traits< ::DDS::PublisherListener>::ref_type p);
 
     /// Destructor
-    virtual ~DDS_PublisherListener_proxy () override = default;
+    ~DDS_PublisherListener_proxy () override = default;
 
     void
     on_offered_deadline_missed (

--- a/ddsx11/dds/dds_topic_listener.h
+++ b/ddsx11/dds/dds_topic_listener.h
@@ -27,7 +27,7 @@ namespace DDSX11
     /// Destructor
     virtual ~DDS_TopicListener_proxy () = default;
 
-    virtual void
+    void
     on_inconsistent_topic (
       DDS_Native::DDS::Topic* the_topic,
       const DDS_Native::DDS::InconsistentTopicStatus& status) override;

--- a/tests/dance/interceptors/interceptor/test_interceptor.h
+++ b/tests/dance/interceptors/interceptor/test_interceptor.h
@@ -30,68 +30,68 @@ namespace DAnCEX11
 
     virtual ~Test_Interceptor ();
 
-    virtual void
+    void
     configure (const Deployment::Properties &config) override;
 
-    virtual void
+    void
     preprocess_plan (Deployment::DeploymentPlan &plan) override;
 
-    virtual void
+    void
     pre_install (Deployment::DeploymentPlan &plan,
       uint32_t instanceRef) override;
 
-    virtual void
+    void
     post_install (const Deployment::DeploymentPlan &plan,
       uint32_t index,
       const CORBA::Any &reference,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     post_endpoint_reference (const Deployment::DeploymentPlan &plan,
       uint32_t connectionRef,
       const CORBA::Any &endpoint_reference,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     pre_connect (Deployment::DeploymentPlan &plan,
       uint32_t connection_index,
       CORBA::Any &provided_reference) override;
 
-    virtual void
+    void
     post_connect (const Deployment::DeploymentPlan &plan,
       uint32_t connectionRef,
       const CORBA::Any &exceptionThrown) override;
 
-    virtual void
+    void
     pre_disconnect (Deployment::DeploymentPlan &plan,
       uint32_t connection_index) override;
 
-    virtual void
+    void
     post_disconnect (const Deployment::DeploymentPlan &plan,
       uint32_t connectionRef,
       const CORBA::Any &exceptionThrown) override;
 
-    virtual void
+    void
     post_configured (const Deployment::DeploymentPlan &plan,
       uint32_t instanceRef,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     post_activate (const Deployment::DeploymentPlan &plan,
       uint32_t instanceRef,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     post_passivate (const Deployment::DeploymentPlan &plan,
       uint32_t instanceRef,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     post_remove (const Deployment::DeploymentPlan &plan,
       uint32_t instanceRef,
       const CORBA::Any &exception_thrown) override;
 
-    virtual void
+    void
     unexpected_event (const Deployment::DeploymentPlan &plan,
       uint32_t instanceRef,
       const CORBA::Any &exception_thrown,

--- a/tests/external/servant/server/hello.h
+++ b/tests/external/servant/server/hello.h
@@ -20,21 +20,17 @@ public:
   Hello (IDL::traits<CORBA::ORB>::ref_type orb);
   virtual ~Hello ();
 
-  virtual
   std::string
   get_string (
       int32_t answer) override;
 
-  virtual
   int16_t
   interface_attrib () override;
 
-  virtual
   void
   interface_attrib (
       int16_t _v) override;
 
-  virtual
   void
   shutdown () override;
 


### PR DESCRIPTION
    * connectors/dds4ccm/impl/dds4ccm_data_listener_t.h:
    * connectors/dds4ccm/impl/dds4ccm_state_listener_t.h:
    * connectors/dds4ccm/tests/log_formatters/main.cpp:
    * connectors/dds4ccm/tests/type_support/main.cpp:
    * connectors/psdd4ccm/tests/custom-serializer/serializer/topic_zmq_ser.h:
    * ddsx11/dds/dds_publisher_listener.h:
    * ddsx11/dds/dds_topic_listener.h:
    * tests/dance/interceptors/interceptor/test_interceptor.h:
    * tests/external/servant/server/hello.h: