### PR TITLE
Move DDS_TypeFactory_T to its own header 

### DIFF
--- a/brix/ciaox11/templates/brix11/apc/idl/opendds/specific_section.erb
+++ b/brix/ciaox11/templates/brix11/apc/idl/opendds/specific_section.erb
@@ -4,7 +4,8 @@ TypeSupport_Files {
   dcps_ts_flags += -o <%= gen_dir %> <%= includes_flags %> -I<%= gen_dir %> \
                    -Wb,export_macro=<%= recipe.export_name.upcase %>_TYPESUPPORT_Export \
                    -Wb,export_include=<%= recipe.export_name %>_typesupport_export.h
-  gendir=<%= gen_dir %>
+  // Temporarily disabled to prevent double directory generation #4326
+  // gendir=<%= gen_dir %>
 % sources.each do |f|
   <%= f %>
 % end

--- a/ddsx11/dds/dds_data_writer.h
+++ b/ddsx11/dds/dds_data_writer.h
@@ -12,7 +12,6 @@
 #define DDSX11_IMPL_DATA_WRITER_H_
 
 #include "dds/dds_proxy_traits_t.h"
-#include "dds/dds_common.h"
 
 #if !defined (DDSX11_HAS_VENDOR_TYPEDEFS)
 namespace DDS_Native {

--- a/ddsx11/dds/dds_domain_participant_listener.cpp
+++ b/ddsx11/dds/dds_domain_participant_listener.cpp
@@ -12,6 +12,8 @@
 #include "dds/dds_type_support.h"
 #include "dds/dds_vendor_adapter.h"
 #include "dds/dds_proxy_entity_manager.h"
+#include "dds/dds_topic.h"
+#include "dds/dds_vendor_conversion_traits.h"
 
 namespace DDSX11
 {

--- a/ddsx11/dds/dds_type_support.cpp
+++ b/ddsx11/dds/dds_type_support.cpp
@@ -9,6 +9,7 @@
  */
 #include "dds/dds_common.h"
 #include "dds/dds_type_support.h"
+#include "logger/ddsx11_log.h"
 
 namespace DDSX11
 {

--- a/ddsx11/dds/dds_type_support.h
+++ b/ddsx11/dds/dds_type_support.h
@@ -14,10 +14,7 @@
 #include "dds/dds_export.h"
 #include "dds/dds_common.h"
 #include "dds/dds_traits.h"
-#include "dds/dds_data_writer_t.h"
-#include "dds/dds_data_reader_t.h"
-#include "dds/dds_traits.h"
-
+#include "idl/dds_dcpsC.h"
 #include <map>
 
 namespace DDSX11
@@ -69,38 +66,6 @@ namespace DDSX11
       DDS_TypeFactory_i_ref& operator=(DDS_TypeFactory_i_ref&&) = delete;
       uint32_t ref_count_ { 1 };
       std::shared_ptr<DDS_TypeFactory_i> tf_;
-  };
-
-  template <typename TOPIC_TYPE, typename TOPIC_SEQ_TYPE, typename NATIVE_SEQ_TYPE, typename NATIVE_DATAREADER_TYPE, typename NATIVE_DATAWRITER_TYPE>
-  class DDS_TypeFactory_T final
-    : public DDS_TypeFactory_i
-  {
-  public:
-    IDL::traits< ::DDS::DataWriter>::ref_type
-    create_datawriter (DDS_Native::DDS::DataWriter *dw) override
-    {
-      typedef DDSX11::DataWriter_T<
-          TOPIC_TYPE,
-          NATIVE_DATAWRITER_TYPE,
-          typename ::DDS::traits<TOPIC_TYPE>::datawriter_type>
-        DataWriter_type;
-      auto proxy = TAOX11_CORBA::make_reference<DataWriter_type>(dw);
-      return proxy;
-    }
-
-    IDL::traits< ::DDS::DataReader>::ref_type
-    create_datareader (DDS_Native::DDS::DataReader *dr) override
-    {
-      typedef DDSX11::DataReader_T<
-          NATIVE_DATAREADER_TYPE,
-          typename ::DDS::traits<TOPIC_TYPE>::datareader_type,
-          TOPIC_TYPE,
-          TOPIC_SEQ_TYPE,
-          NATIVE_SEQ_TYPE>
-        DataReader_type;
-      auto proxy = TAOX11_CORBA::make_reference<DataReader_type> (dr);
-      return proxy;
-    }
   };
 
   class DDSX11_IMPL_Export DDS_TypeSupport_i final

--- a/ddsx11/dds/dds_type_support.h
+++ b/ddsx11/dds/dds_type_support.h
@@ -12,10 +12,18 @@
 #define DDSX11_IMPL_TYPE_SUPPORT_H_
 
 #include "dds/dds_export.h"
-#include "dds/dds_common.h"
 #include "dds/dds_traits.h"
 #include "idl/dds_dcpsC.h"
 #include <map>
+
+#if !defined (DDSX11_HAS_VENDOR_TYPEDEFS)
+namespace DDS_Native {
+  namespace DDS {
+    class DataWriter;
+    class DataReader;
+  }
+}
+#endif /* DDSX11_HAS_VENDOR_TYPEDEFS */
 
 namespace DDSX11
 {

--- a/ddsx11/dds/dds_typefactory_t.h
+++ b/ddsx11/dds/dds_typefactory_t.h
@@ -1,0 +1,51 @@
+// -*- C++ -*-
+/**
+ * @file    dds_typefactory_t.h
+ * @author  Johnny Willemsen
+ *
+ * @brief   Templated type factory for creating datareaders/datawriter
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+#ifndef DDSX11_IMPL_TYPEFACTORY_T_H_
+#define DDSX11_IMPL_TYPEFACTORY_T_H_
+
+#include "dds/dds_data_writer_t.h"
+#include "dds/dds_data_reader_t.h"
+
+namespace DDSX11
+{
+  template <typename TOPIC_TYPE, typename TOPIC_SEQ_TYPE, typename NATIVE_SEQ_TYPE, typename NATIVE_DATAREADER_TYPE, typename NATIVE_DATAWRITER_TYPE>
+  class DDS_TypeFactory_T final
+    : public DDS_TypeFactory_i
+  {
+  public:
+    IDL::traits< ::DDS::DataWriter>::ref_type
+    create_datawriter (DDS_Native::DDS::DataWriter *dw) override
+    {
+      typedef DDSX11::DataWriter_T<
+          TOPIC_TYPE,
+          NATIVE_DATAWRITER_TYPE,
+          typename ::DDS::traits<TOPIC_TYPE>::datawriter_type>
+        DataWriter_type;
+      auto proxy = TAOX11_CORBA::make_reference<DataWriter_type>(dw);
+      return proxy;
+    }
+
+    IDL::traits< ::DDS::DataReader>::ref_type
+    create_datareader (DDS_Native::DDS::DataReader *dr) override
+    {
+      typedef DDSX11::DataReader_T<
+          NATIVE_DATAREADER_TYPE,
+          typename ::DDS::traits<TOPIC_TYPE>::datareader_type,
+          TOPIC_TYPE,
+          TOPIC_SEQ_TYPE,
+          NATIVE_SEQ_TYPE>
+        DataReader_type;
+      auto proxy = TAOX11_CORBA::make_reference<DataReader_type> (dr);
+      return proxy;
+    }
+  };
+}
+
+#endif /* DDSX11_IMPL_TYPEFACTORY_T_H_ */

--- a/ddsx11/dds/ddsx11_impl.mpc
+++ b/ddsx11/dds/ddsx11_impl.mpc
@@ -76,6 +76,7 @@ project(ddsx11_core_impl) : install, \
     dds_native_entity_t.cpp
     dds_native_entity_t.h
     dds_proxy_traits_t.h
+    dds_typefactory_t.h
   }
 
   specific {

--- a/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
@@ -13,6 +13,10 @@
 #include "dds/ndds_publisher_listener.h"
 #include "dds/dds_type_support.h"
 #include "dds/ndds_utils.h"
+#include "dds/dds_topic.h"
+#include "dds/dds_data_writer_listener.h"
+#include "dds/ndds_base_traits.h"
+#include "dds/dds_proxy_entity_manager.h"
 
 namespace DDSX11
 {

--- a/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
@@ -10,12 +10,13 @@
  */
 #include "dds/dds_common.h"
 #include "dds/ndds_subscriber.h"
-
 #include "dds/dds_data_reader_listener.h"
-
 #include "dds/ndds_utils.h"
 #include "dds/ndds_base_traits.h"
 #include "dds/dds_type_support.h"
+#include "dds/dds_content_filtered_topic.h"
+#include "dds/dds_topic.h"
+#include "dds/dds_proxy_entity_manager.h"
 
 namespace DDSX11
 {

--- a/ridlbe/ccmx11/facets/dds/visitors/pre.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/pre.rb
@@ -25,6 +25,7 @@ module IDL
           self.ddsx11_incl << 'dds/dds_domain_participant_factory.h'
           self.ddsx11_incl << 'dds/dds_domain_participant.h'
           self.ddsx11_incl << 'dds/dds_type_support.h'
+          self.ddsx11_incl << 'dds/dds_typefactory_t.h'
         end
         ddsx11_incl
       end


### PR DESCRIPTION
Reduces the places where DDS vendor headers are exposed to user code