### PR TITLE
Only call max_delivered_data() once, just use the value we just retri…

### DIFF
--- a/connectors/dds4ccm/impl/dds4ccm_data_listener_t.cpp
+++ b/connectors/dds4ccm/impl/dds4ccm_data_listener_t.cpp
@@ -64,7 +64,7 @@ namespace CIAOX11
         int32_t max_samples = this->control_->max_delivered_data ();
 
         if (mode == ::CCM_DDS::ListenerMode::ONE_BY_ONE ||
-          this->control_->max_delivered_data () == 0)
+            max_samples == 0)
         {
           // Read everything. In case ONE_BY_ONE, the samples are provided to
           // the user one by one (on_one_data);

--- a/connectors/dds4ccm/impl/dds4ccm_state_listener_t.cpp
+++ b/connectors/dds4ccm/impl/dds4ccm_state_listener_t.cpp
@@ -67,7 +67,7 @@ namespace CIAOX11
         int32_t max_samples = this->control_->max_delivered_data ();
 
         if (mode == ::CCM_DDS::ListenerMode::ONE_BY_ONE ||
-          this->control_->max_delivered_data () == 0)
+            max_samples == 0)
         {
           // Read everything. In case ONE_BY_ONE, the samples are provided to
           // the user one by one (on_one_data);


### PR DESCRIPTION
…eve to compare with zero

    * connectors/dds4ccm/impl/dds4ccm_data_listener_t.cpp:
    * connectors/dds4ccm/impl/dds4ccm_state_listener_t.cpp: