### PR TITLE
Changed type for samples_received_ to remove a cast and use constexpr…

### DIFF
--- a/connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.cpp
@@ -14,7 +14,7 @@
 //@@{__RIDL_REGEN_MARKER__} - END : Uni_Receiver_Impl[user_includes]
 
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : Uni_Receiver_Impl[user_global_impl]
-#define SAMPLES_EXPECTED 2*3+1
+constexpr ::Uni::TopUnionMessageSeq::size_type SAMPLES_EXPECTED { 2*3+1 };
 //@@{__RIDL_REGEN_MARKER__} - END : Uni_Receiver_Impl[user_global_impl]
 
 namespace Uni_Receiver_Impl
@@ -84,10 +84,11 @@ namespace Uni_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Uni_Receiver_Impl::info_out_data_listener_exec_i::on_many_data[_data_infos]
     X11_UNUSED_ARG(infos);
 
-    this->samples_received_ += ACE_Utils::truncate_cast<uint16_t> (data.size ());
+    this->samples_received_ += data.size ();
 
     for (const Uni::TopUnionMessage& msg : data)
     {
+      DDS4CCM_TEST_DEBUG << "Received: <" << msg << ">" << std::endl;
       if (msg._d () == 4)
       {
         if (msg.x () != 5)

--- a/connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.h
+++ b/connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.h
@@ -78,7 +78,7 @@ namespace Uni_Receiver_Impl
     /** @name User defined members. */
     //@{
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Uni_Receiver_Impl::info_out_data_listener_exec_i[user_members]
-    uint16_t samples_received_ {};
+    ::Uni::TopUnionMessageSeq::size_type samples_received_ {};
     //@@{__RIDL_REGEN_MARKER__} - END : Uni_Receiver_Impl::info_out_data_listener_exec_i[user_members]
     //@}
 


### PR DESCRIPTION
… instead of a define

    * connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.cpp:
    * connectors/dds4ccm/tests/union/toplevel/receiver/top_union_receiver_exec.h: