### PR TITLE
Make ddsx11 log formatters test more vendor independent

### DIFF
--- a/ddsx11/tests/log_formatters/log_check.pl
+++ b/ddsx11/tests/log_formatters/log_check.pl
@@ -19,8 +19,23 @@ sub check_policy_count
 {
     my $line = shift;
     print $line;
-    if ($line =~ "DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID" &&
+    if ($line =~ "DDS::PRESENTATION_QOS_POLICY_ID" &&
         $line =~ "count=5")
+    {
+      return 1;
+    }
+  return 0;
+}
+
+# Check the instance handle, returns 1 in case of ok, 0 in case of a failure
+sub check_instance_handle
+{
+    my $line = shift;
+    if ($line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F" )
+    {
+      return 1;
+    }
+    if ($line =~ "6" )
     {
       return 1;
     }
@@ -67,7 +82,7 @@ while (my $line = <FILE>)
     }
     elsif ($line =~ "Logging StatusKind")
     {
-        if ($line =~ "RELIABLE_WRITER_CACHE_CHANGED_STATUS")
+        if ($line =~ "DDS::RELIABLE_WRITER_CACHE_CHANGED_STATUS")
         {
             $found=$found+1;
         }
@@ -78,7 +93,7 @@ while (my $line = <FILE>)
     }
     elsif ($line =~ "Logging InstanceHandle_t")
     {
-        if ($line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+        if (check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -89,7 +104,7 @@ while (my $line = <FILE>)
     }
     elsif ($line =~ "Logging DDS::Entity")
     {
-        if ($line =~ "0XF0E0D0C,0XB0A0908,0X7060504,0X3020100")
+        if (check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -113,7 +128,7 @@ while (my $line = <FILE>)
     {
         if ($line =~ "total_count=6" && $line =~ "total_count_change=11" &&
             $line =~ "last_instance_handle=" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -137,7 +152,7 @@ while (my $line = <FILE>)
     {
         if ($line =~ "total_count=15" && $line =~ "total_count_change=20" &&
             $line =~ "REJECTED_BY_SAMPLES_LIMIT" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -150,7 +165,7 @@ while (my $line = <FILE>)
     {
         if ($line =~ "total_count=7" && $line =~ "total_count_change=12" &&
             $line =~ "last_instance_handle=" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -179,7 +194,7 @@ while (my $line = <FILE>)
     {
         $start_found = $found;
         if ($line =~ "total_count=12" && $line =~ "total_count_change=17" &&
-            $line =~ "last_policy_id=DDS::DATAWRITERRESOURCELIMITS_QOS_POLICY_ID")
+            $line =~ "last_policy_id=DDS::READERDATALIFECYCLE_QOS_POLICY_ID")
         {
             $found=$found+1;
         }
@@ -196,7 +211,7 @@ while (my $line = <FILE>)
         if ($line =~ "total_count=20" && $line =~ "total_count_change=15" &&
             $line =~ "current_count=12" && "current_count_change=7" &&
             $line =~ "last_subscription_handle=" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -210,7 +225,7 @@ while (my $line = <FILE>)
         if ($line =~ "total_count=7" && $line =~ "total_count_change=12" &&
             $line =~ "current_count=15" && "current_count_change=20" &&
             $line =~ "last_publication_handle=" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -235,7 +250,7 @@ while (my $line = <FILE>)
         if ($line =~ "alive_count=9" && $line =~ "not_alive_count=14" &&
             $line =~ "alive_count_change=16" && $line =~ "not_alive_count_change=21" &&
             $line =~ "last_publication_handle=" &&
-            $line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F")
+            check_instance_handle($line))
         {
             $found=$found+1;
         }
@@ -257,7 +272,7 @@ while (my $line = <FILE>)
     }
     elsif ($line =~ "Logging DDS::QosPolicyId_t")
     {
-        if ($line =~ "DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID")
+        if ($line =~ "DDS::INVALID_QOS_POLICY_ID")
         {
             $found=$found+1;
         }

--- a/ddsx11/tests/log_formatters/main.cpp
+++ b/ddsx11/tests/log_formatters/main.cpp
@@ -35,7 +35,7 @@ public:
 #if defined DDSX11_NDDS
     return DDS::InstanceHandle_t {{{15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0}}, 16, false};
 #else
-    return DDS::InstanceHandle_t {{0}};
+    return DDS::InstanceHandle_t {{6}};
 #endif
   }
 };
@@ -45,8 +45,8 @@ int main (int, char **)
   std::ostringstream ostr;
 
   ::DDS::QosPolicyCountSeq policy_count_seq;
-#if defined DDSX11_NDDS
-  ::DDS::QosPolicyCount const policy_count (::DDS::DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID, 5);
+
+  ::DDS::QosPolicyCount const policy_count (::DDS::PRESENTATION_QOS_POLICY_ID, 5);
   DDSX11_TEST_DEBUG << "Logging QosPolicyCount : " << DDS::dds_write (policy_count) << std::endl;
   ostr << "Logging QosPolicyCount : " << DDS::dds_write (policy_count) << std::endl;
 
@@ -55,7 +55,6 @@ int main (int, char **)
   policy_count_seq.push_back (policy_count);
   DDSX11_TEST_DEBUG << "Logging QosPolicyCountSeq : " << DDS::dds_write (policy_count_seq) << std::endl;
   ostr << "Logging QosPolicyCountSeq : " << DDS::dds_write (policy_count_seq) << std::endl;
-#endif /* DDSX11_NDDS */
 
   ::DDS::Time_t const time (15, 0);
   DDSX11_TEST_DEBUG << "Logging Time_t : " << DDS::dds_write (time) << std::endl;
@@ -120,14 +119,12 @@ int main (int, char **)
   ostr << "Logging DDS::OfferedDeadlineMissedStatus : "
     << DDS::dds_write (offered_deadline_missed_status) << std::endl;
 
-#if defined DDSX11_NDDS
   DDS::OfferedIncompatibleQosStatus const offered_incompatible_qos_status (
-    12, 17, ::DDS::DATAWRITERRESOURCELIMITS_QOS_POLICY_ID, policy_count_seq);
+    12, 17, ::DDS::READERDATALIFECYCLE_QOS_POLICY_ID, policy_count_seq);
   DDSX11_TEST_DEBUG << "Logging DDS::OfferedIncompatibleQosStatus : "
     << DDS::dds_write (offered_incompatible_qos_status) << std::endl;
   ostr << "Logging DDS::OfferedIncompatibleQosStatus : "
     << DDS::dds_write (offered_incompatible_qos_status) << std::endl;
-#endif /* DDSX11_NDDS */
 
   DDS::PublicationMatchedStatus const publication_matched_status (
     20, 15, 12, 7, instance_handle);
@@ -162,13 +159,11 @@ int main (int, char **)
   ostr << "Logging DDS::Duration_t : "
     << DDS::dds_write (duration) << std::endl;
 
-#if defined DDSX11_NDDS
-  DDS::QosPolicyId_t const policy_id (DDS::DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID);
+  DDS::QosPolicyId_t const policy_id (DDS::INVALID_QOS_POLICY_ID);
   DDSX11_TEST_DEBUG << "Logging DDS::QosPolicyId_t : "
     << DDS::dds_write (policy_id) << std::endl;
   ostr << "Logging DDS::QosPolicyId_t : "
     << DDS::dds_write (policy_id) << std::endl;
-#endif /* DDSX11_NDDS */
 
   DDS::StatusMask const mask_pub_match { DDS::PUBLICATION_MATCHED_STATUS };
   DDS::StatusMask const mask_pub_data_match { DDS::PUBLICATION_MATCHED_STATUS | DDS::DATA_ON_READERS_STATUS };


### PR DESCRIPTION
    * ddsx11/tests/log_formatters/log_check.pl:
    * ddsx11/tests/log_formatters/main.cpp: