### PR TITLE
For the test of StatusKind logging use a kind which is from the DDS s…

### DIFF
--- a/ddsx11/tests/log_formatters/log_check.pl
+++ b/ddsx11/tests/log_formatters/log_check.pl
@@ -31,11 +31,11 @@ sub check_policy_count
 sub check_instance_handle
 {
     my $line = shift;
-    if ($line =~ "0X10203,0X4050607,0X8090A0B,0XC0D0E0F" )
+    if ($line =~ "{0X10203,0X4050607,0X8090A0B,0XC0D0E0F}" )
     {
       return 1;
     }
-    if ($line =~ "6" )
+    if ($line =~ "{1234567}" )
     {
       return 1;
     }
@@ -82,7 +82,7 @@ while (my $line = <FILE>)
     }
     elsif ($line =~ "Logging StatusKind")
     {
-        if ($line =~ "DDS::RELIABLE_WRITER_CACHE_CHANGED_STATUS")
+        if ($line =~ "DDS::LIVELINESS_LOST_STATUS")
         {
             $found=$found+1;
         }

--- a/ddsx11/tests/log_formatters/main.cpp
+++ b/ddsx11/tests/log_formatters/main.cpp
@@ -35,7 +35,7 @@ public:
 #if defined DDSX11_NDDS
     return DDS::InstanceHandle_t {{{15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0}}, 16, false};
 #else
-    return DDS::InstanceHandle_t {{6}};
+    return DDS::InstanceHandle_t {{1234567}};
 #endif
   }
 };
@@ -60,16 +60,14 @@ int main (int, char **)
   DDSX11_TEST_DEBUG << "Logging Time_t : " << DDS::dds_write (time) << std::endl;
   ostr << "Logging Time_t : " << DDS::dds_write (time) << std::endl;
 
-#if defined DDSX11_NDDS
-  ::DDS::StatusKind const status_kind (::DDS::RELIABLE_WRITER_CACHE_CHANGED_STATUS);
+  ::DDS::StatusKind const status_kind (::DDS::LIVELINESS_LOST_STATUS);
   DDSX11_TEST_DEBUG << "Logging StatusKind : " << DDS::dds_write (status_kind) << std::endl;
   ostr << "Logging StatusKind : " << DDS::dds_write (status_kind) << std::endl;
-#endif /* DDSX11_NDDS */
 
 #if defined DDSX11_NDDS
   DDS::InstanceHandle_t const instance_handle ({{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}}, 16, true);
 #else
-  DDS::InstanceHandle_t const instance_handle {{6}};
+  DDS::InstanceHandle_t const instance_handle {{1234567}};
 #endif /* DDSX11_NDDS */
   DDSX11_TEST_DEBUG << "Logging InstanceHandle_t : " << DDS::dds_write(instance_handle) << std::endl;
   ostr << "Logging InstanceHandle_t : " << DDS::dds_write(instance_handle) << std::endl;

--- a/ddsx11/tests/log_formatters/main.cpp
+++ b/ddsx11/tests/log_formatters/main.cpp
@@ -33,7 +33,7 @@ public:
   DDS::InstanceHandle_t get_instance_handle() override
   {
 #if defined DDSX11_NDDS
-    return DDS::InstanceHandle_t {{{15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0}}, 16, false};
+    return DDS::InstanceHandle_t {{{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}}, 16, false};
 #else
     return DDS::InstanceHandle_t {{1234567}};
 #endif


### PR DESCRIPTION
…pec, made the InstanceHandle_t checking more strict

    * ddsx11/tests/log_formatters/log_check.pl:
    * ddsx11/tests/log_formatters/main.cpp: