### PR TITLE
DDSX11 portability enhancements

### DIFF
--- a/ddsx11/examples/shapes/base/shapetype.mpc
+++ b/ddsx11/examples/shapes/base/shapetype.mpc
@@ -24,33 +24,41 @@ project (*stub) : ddsx11_stub {
   }
 }
 
-project (*ddsx11_ts) : ddsx11_vendor_ts_defaults {
+project (*ddsx11_ndds_ts) : ddsx11_vendor_ts_defaults {
   after += *idl
+  requires += ndds
   NDDSTypeSupport_Files {
     gendir = GeneratedCode
     GeneratedCode/shapetype_dds.idl
   }
-//  TypeSupport_Files {
-//    gendir = GeneratedCode
-//    GeneratedCode/shapetype_dds.idl
-//    dcps_ts_flags += -o GeneratedCode \
-//                     -Wb,export_macro=SHAPES_TYPESUPPORT_Export \
-//                     -Wb,export_include=shapes_typesupport_export.h
-//  }
-//  IDL_Files {
-//    gendir = GeneratedCode
-//    GeneratedCode/shapetype_dds.idl
-//    GeneratedCode/shapetype_ddsTypeSupport.idl
-//    idlflags += -Wb,stub_export_macro=SHAPES_TYPESUPPORT_Export \
-//                -Wb,stub_export_include=shapes_typesupport_export.h \
-//                -IGeneratedCode -o GeneratedCode
-//  }
   custom_only=1
 }
 
-project (*ddsx11_impl) : ddsx11_impl {
-  after += *stub *ddsx11_ts
+project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults {
+  after += *idl
+  requires += opendds
+  idlflags += -o GeneratedCode -I. -IGeneratedCode -SS
+  TypeSupport_Files {
+    gendir = GeneratedCode
+    GeneratedCode/shapetype_dds.idl
+    dcps_ts_flags += -Wb,export_macro=SHAPES_TYPESUPPORT_Export \
+                     -Wb,export_include=shapes_typesupport_export.h
+  }
+  IDL_Files {
+    gendir = GeneratedCode
+    GeneratedCode/shapetype_dds.idl
+    GeneratedCode/shapetype_ddsTypeSupport.idl
+    idlflags += -Wb,stub_export_macro=SHAPES_TYPESUPPORT_Export \
+                -Wb,stub_export_include=shapes_typesupport_export.h
+  }
+  custom_only=1
+}
+
+project (*ddsx11_ndds_impl) : ddsx11_impl {
+  after += *stub *ddsx11_ndds_ts
   libs += *stub
+  requires += ndds
+  sharedname = shapetype_ddsx11_impl
 
   dynamicflags += SHAPES_TYPESUPPORT_BUILD_DLL
 
@@ -61,10 +69,6 @@ project (*ddsx11_impl) : ddsx11_impl {
     GeneratedCode/shapetype_dds.cxx
     GeneratedCode/shapetype_ddsPlugin.cxx
     GeneratedCode/shapetype_ddsSupport.cxx
-//    GeneratedCode/shapetype_ddsC.cpp
-//    GeneratedCode/shapetype_ddsTypeSupportC.cpp
-//    GeneratedCode/shapetype_ddsTypeSupportImpl.cpp
-//    GeneratedCode/shapetype_ddsTypeSupportS.cpp
     GeneratedCode/shapetype_dds_typesupport.cpp
   }
 
@@ -72,6 +76,32 @@ project (*ddsx11_impl) : ddsx11_impl {
     GeneratedCode/shapetype_dds.h
     GeneratedCode/shapetype_ddsPlugin.h
     GeneratedCode/shapetype_ddsSupport.h
+    GeneratedCode/shapetype_dds_typesupport.h
+  }
+}
+
+project (*ddsx11_opendds_impl) : ddsx11_impl {
+  after += *stub *ddsx11_opendds_ts
+  libs += *stub
+  requires += opendds
+  sharedname = shapetype_ddsx11_impl
+
+  dynamicflags += SHAPES_TYPESUPPORT_BUILD_DLL
+
+  libout    = ../lib
+  libpaths += ../lib
+
+  Source_Files {
+    GeneratedCode/shapetype_ddsC.cpp
+    GeneratedCode/shapetype_ddsTypeSupportC.cpp
+    GeneratedCode/shapetype_ddsTypeSupportImpl.cpp
+    GeneratedCode/shapetype_dds_typesupport.cpp
+  }
+
+  Header_Files {
+    GeneratedCode/shapetype_ddsC.h
+    GeneratedCode/shapetype_ddsTypeSupportC.h
+    GeneratedCode/shapetype_ddsTypeSupportImpl.h
     GeneratedCode/shapetype_dds_typesupport.h
   }
 }

--- a/ddsx11/examples/shapes/base/shapetype.mpc
+++ b/ddsx11/examples/shapes/base/shapetype.mpc
@@ -34,10 +34,9 @@ project (*ddsx11_ndds_ts) : ddsx11_vendor_ts_defaults {
   custom_only=1
 }
 
-project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults {
+project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
   after += *idl
   requires += opendds
-  idlflags += -o GeneratedCode -I. -IGeneratedCode -SS
   TypeSupport_Files {
     gendir = GeneratedCode
     GeneratedCode/shapetype_dds.idl
@@ -49,7 +48,8 @@ project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults {
     GeneratedCode/shapetype_dds.idl
     GeneratedCode/shapetype_ddsTypeSupport.idl
     idlflags += -Wb,stub_export_macro=SHAPES_TYPESUPPORT_Export \
-                -Wb,stub_export_include=shapes_typesupport_export.h
+                -Wb,stub_export_include=shapes_typesupport_export.h \
+                -o GeneratedCode -I. -IGeneratedCode -SS
   }
   custom_only=1
 }

--- a/ddsx11/examples/shapes/receiver/x11_shapes_receiver.mpc
+++ b/ddsx11/examples/shapes/receiver/x11_shapes_receiver.mpc
@@ -1,6 +1,6 @@
 project(*i2c_shapes_receiver) : ddsx11_impl {
 
-  after += shapetype_stub shapetype_ddsx11_impl
+  after += shapetype_stub shapetype_ddsx11_opendds_impl shapetype_ddsx11_ndds_impl
   libs  += shapetype_stub shapetype_ddsx11_impl
 
   libpaths += ../lib

--- a/ddsx11/examples/shapes/sender/x11_shapes_sender.mpc
+++ b/ddsx11/examples/shapes/sender/x11_shapes_sender.mpc
@@ -1,6 +1,6 @@
 project(*i2c_shapes_sender) : ddsx11_impl {
 
-  after += shapetype_stub shapetype_ddsx11_impl
+  after += shapetype_stub shapetype_ddsx11_opendds_impl shapetype_ddsx11_ndds_impl
   libs  += shapetype_stub shapetype_ddsx11_impl
 
   libpaths += ../lib

--- a/ddsx11/tests/builtin/base/builtin.mpc
+++ b/ddsx11/tests/builtin/base/builtin.mpc
@@ -51,10 +51,11 @@ project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
   custom_only=1
 }
 
-project (*ddsx11_ndds_impl) : ddsx11_impl, ddsx11_no_idlfiles {
+project (*ddsx11_ndds_impl) : ddsx11_impl {
   after += *stub *ddsx11_ndds_ts
   libs += *stub
   requires += ndds
+  sharedname = builtin_ddsx11_impl
 
   dynamicflags += SHAPES_TYPESUPPORT_BUILD_DLL
 
@@ -80,6 +81,7 @@ project (*ddsx11_opendds_impl) : ddsx11_impl, ddsx11_no_idlfiles {
   after += *stub *ddsx11_opendds_ts
   libs += *stub
   requires += opendds
+  sharedname = builtin_ddsx11_impl
 
   dynamicflags += SHAPES_TYPESUPPORT_BUILD_DLL
 

--- a/ddsx11/tests/builtin/base/builtin.mpc
+++ b/ddsx11/tests/builtin/base/builtin.mpc
@@ -45,6 +45,7 @@ project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
                      -Wb,export_include=shapes_stub_export.h
   }
   IDL_Files {
+    gendir = GeneratedCode
     GeneratedCode/shapetype_dds.idl
     idlflags += -Wb,stub_export_macro=SHAPES_STUB_Export \
                 -Wb,stub_export_include=shapes_stub_export.h \

--- a/ddsx11/tests/builtin/base/builtin.mpc
+++ b/ddsx11/tests/builtin/base/builtin.mpc
@@ -24,7 +24,7 @@ project (*stub) : ddsx11_stub {
   }
 }
 
-project (*ddsx11_ndds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
+project (*ddsx11_ndds_ts) : ddsx11_vendor_ts_defaults {
   after += *idl
   requires += ndds
   NDDSTypeSupport_Files {
@@ -41,6 +41,8 @@ project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
   TypeSupport_Files {
     gendir = GeneratedCode
     GeneratedCode/shapetype_dds.idl
+    dcps_ts_flags += -Wb,export_macro=SHAPES_STUB_Export \
+                     -Wb,export_include=shapes_stub_export.h
   }
   IDL_Files {
     GeneratedCode/shapetype_dds.idl

--- a/ddsx11/tests/builtin/builtin/x11_shapes_builtin.mpc
+++ b/ddsx11/tests/builtin/builtin/x11_shapes_builtin.mpc
@@ -1,6 +1,6 @@
-project(*ndds_builtin) : ddsx11_impl {
-  after += builtin_stub builtin_ddsx11_ndds_impl
-  libs  += builtin_stub builtin_ddsx11_ndds_impl
+project(*builtin) : ddsx11_impl {
+  after += builtin_stub builtin_ddsx11_ndds_impl builtin_ddsx11_opendds_impl
+  libs  += builtin_stub builtin_ddsx11_impl
   requires += ndds
 
   libpaths += ../lib
@@ -15,19 +15,3 @@ project(*ndds_builtin) : ddsx11_impl {
   }
 }
 
-project(*opendds_builtin) : ddsx11_impl {
-  after += builtin_stub builtin_ddsx11_opendds_impl
-  libs  += builtin_stub builtin_ddsx11_opendds_impl
-  requires += opendds
-
-  libpaths += ../lib
-
-  exename = builtin
-  exeout  = ../lib
-
-  includes += ../base/GeneratedCode
-
-  Source_Files {
-    builtin.cpp
-  }
-}

--- a/ddsx11/tests/builtin/builtin/x11_shapes_builtin.mpc
+++ b/ddsx11/tests/builtin/builtin/x11_shapes_builtin.mpc
@@ -1,7 +1,6 @@
 project(*builtin) : ddsx11_impl {
   after += builtin_stub builtin_ddsx11_ndds_impl builtin_ddsx11_opendds_impl
   libs  += builtin_stub builtin_ddsx11_impl
-  requires += ndds
 
   libpaths += ../lib
 

--- a/ddsx11/tests/builtin/double_delete/x11_double_delete.mpc
+++ b/ddsx11/tests/builtin/double_delete/x11_double_delete.mpc
@@ -1,24 +1,6 @@
-project(*ndds_double_delete) : ddsx11_impl {
-  after += builtin_stub builtin_ddsx11_ndds_impl
-  libs  += builtin_stub builtin_ddsx11_ndds_impl
-  requires += ndds
-
-  libpaths += ../lib
-
-  exename = double_delete
-  exeout  = ../lib
-
-  includes += ../base/GeneratedCode
-
-  Source_Files {
-    double_delete.cpp
-  }
-}
-
-project(*opendds_double_delete) : ddsx11_impl {
-  after += builtin_stub builtin_ddsx11_opendds_impl
-  libs  += builtin_stub builtin_ddsx11_opendds_impl
-  requires += opendds
+project(*double_delete) : ddsx11_impl {
+  after += builtin_stub builtin_ddsx11_opendds_impl builtin_ddsx11_ndds_impl
+  libs  += builtin_stub builtin_ddsx11_impl
 
   libpaths += ../lib
 

--- a/ddsx11/tests/logger_backend/log_record.mpc
+++ b/ddsx11/tests/logger_backend/log_record.mpc
@@ -23,8 +23,9 @@ project (*stub) : ddsx11_stub {
   }
 }
 
-project (*ddsx11_ts) : ddsx11_vendor_ts_defaults {
+project (*ddsx11_ndds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
   after += *idl
+  requires += ndds
   NDDSTypeSupport_Files {
     gendir = GeneratedCode
     GeneratedCode/log_record_dds.idl
@@ -32,9 +33,28 @@ project (*ddsx11_ts) : ddsx11_vendor_ts_defaults {
   custom_only=1
 }
 
-project (*ddsx11_impl) : ddsx11_impl {
-  after += *stub *ddsx11_ts
+project (*ddsx11_opendds_ts) : ddsx11_vendor_ts_defaults, ddsx11_no_idlfiles {
+  after += *idl
+  requires += opendds
+  idlflags += -o GeneratedCode -I. -IGeneratedCode -SS
+  TypeSupport_Files {
+    gendir = GeneratedCode
+    GeneratedCode/log_record_dds.idl
+  }
+  IDL_Files {
+    GeneratedCode/log_record_dds.idl
+    idlflags += -Wb,stub_export_macro=LOG_RECORD_STUB_Export \
+                -Wb,stub_export_include=log_record_stub_export.h \
+                -SS
+  }
+  custom_only=1
+}
+
+project (*ddsx11_ndds_impl) : ddsx11_impl {
+  after += *stub *ddsx11_ndds_ts
   libs += *stub
+  requires += ndds
+  sharedname = log_record_ddsx11_impl
 
   dynamicflags += LOG_RECORD_TYPESUPPORT_BUILD_DLL
 
@@ -53,9 +73,32 @@ project (*ddsx11_impl) : ddsx11_impl {
   }
 }
 
+project (*ddsx11_opendds_impl) : ddsx11_impl, ddsx11_no_idlfiles {
+  after += *stub *ddsx11_opendds_ts
+  libs += *stub
+  requires += opendds
+  sharedname = log_record_ddsx11_impl
+
+  dynamicflags += LOG_RECORD_TYPESUPPORT_BUILD_DLL
+
+  Source_Files {
+    GeneratedCode/log_record_ddsC.cpp
+    GeneratedCode/log_record_ddsTypeSupportC.cpp
+    GeneratedCode/log_record_ddsTypeSupportImpl.cpp
+    GeneratedCode/log_record_dds_typesupport.cpp
+  }
+
+  Header_Files {
+    GeneratedCode/log_record_ddsC.h
+    GeneratedCode/log_record_ddsTypeSupportC.h
+    GeneratedCode/log_record_ddsTypeSupportImpl.
+    GeneratedCode/log_record_dds_typesupport.h
+  }
+}
+
 project(*ddsx11_logger) : ddsx11_impl, ddsx11_logger {
   dynamicflags += DNCX11_LOG_BACKEND_BUILD_DLL
-  after += log_record_stub log_record_ddsx11_impl
+  after += log_record_stub log_record_ddsx11_opendds_impl log_record_ddsx11_ndds_impl
   libs  += log_record_stub log_record_ddsx11_impl
 
   includes += GeneratedCode
@@ -69,7 +112,7 @@ project(*ddsx11_logger) : ddsx11_impl, ddsx11_logger {
 }
 
 project(*log_server) : ddsx11_impl {
-  after += log_record_stub log_record_ddsx11_impl
+  after += log_record_stub record_ddsx11_opendds_impl log_record_ddsx11_ndds_impl
   libs  += log_record_stub log_record_ddsx11_impl
 
   exename = log_server

--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_ndds_idl_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_ndds_idl_defaults.mpb
@@ -5,5 +5,5 @@
 // --------------------------------------------------------------------
 
 project : ddsx11_ndds_flags, ridl_defaults {
-  idlflags += -Scdr -I$(CIAOX11_ROOT)/ddsx11/vendors/ndds/idl
+  idlflags += -Scdr -I$(CIAOX11_ROOT)/ddsx11/vendors/ndds/idl -SS -Ssh
 }

--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -10,6 +10,9 @@ feature(ddsx11, ndds) : ndds_ts_defaults {
   ndds_ts_flags += -enableEscapeChar
   Define_Custom(TypeSupport) {
   }
+  Define_Custom(DummyTypeSupport) {
+    keyword dcps_ts_flags = commandflags
+  }
 }
 
 feature(ddsx11, ndds_no_optimize) : ndds_ts_defaults {

--- a/ddsx11/vendors/ndds/idl/ddsx11_ndds_stub.mpc
+++ b/ddsx11/vendors/ndds/idl/ddsx11_ndds_stub.mpc
@@ -6,6 +6,7 @@ project (ddsx11_ndds_types_idl_gen) : install, \
   custom_only = 1
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
               -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
+              -SS
   // Do not suppress cdr streaming since anytypecode needs it..
   // TODO CHECK
   idlflags -= -Scdr
@@ -26,7 +27,7 @@ project (ddsx11_ndds_dcps_all_idl_gen) : install, \
   custom_only = 1
   idlflags += -Sddsx11,nddslfc \
               -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
-              -Wb,stub_export_include=ddsx11_ndds_stub_export.h -Scp
+              -Wb,stub_export_include=ddsx11_ndds_stub_export.h -Scp -SS
 
   IDL_Files {
     ndds_dcps_all.idl
@@ -43,7 +44,7 @@ project (ddsx11_ndds_instancehandle_idl_gen) : install, \
   custom_only = 1
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
               -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
-              -Wb,post_include=idl/ndds_dcps_instance_handle.h -Scp
+              -Wb,post_include=idl/ndds_dcps_instance_handle.h -Scp -SS
 
   IDL_Files {
     ndds_dcps_instance_handle.idl
@@ -60,7 +61,7 @@ project (ddsx11_ndds_dcps_idl_gen) : install, \
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
               -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
               -Wb,post_include=idl/dds_log_formatters.h \
-              -Glem -Gxhst
+              -Glem -Gxhst -SS
 
   // Make sure we first compile the vendor specific IDL
   after += ddsx11_ndds_types_idl_gen ddsx11_ndds_instancehandle_idl_gen ddsx11_ndds_dcps_all_idl_gen

--- a/ddsx11/vendors/ndds/idl/ddsx11_ndds_stub.mpc
+++ b/ddsx11/vendors/ndds/idl/ddsx11_ndds_stub.mpc
@@ -5,8 +5,7 @@ project (ddsx11_ndds_types_idl_gen) : install, \
 {
   custom_only = 1
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
-              -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
-              -SS
+              -Wb,stub_export_include=ddsx11_ndds_stub_export.h
   // Do not suppress cdr streaming since anytypecode needs it..
   // TODO CHECK
   idlflags -= -Scdr
@@ -27,7 +26,7 @@ project (ddsx11_ndds_dcps_all_idl_gen) : install, \
   custom_only = 1
   idlflags += -Sddsx11,nddslfc \
               -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
-              -Wb,stub_export_include=ddsx11_ndds_stub_export.h -Scp -SS
+              -Wb,stub_export_include=ddsx11_ndds_stub_export.h -Scp
 
   IDL_Files {
     ndds_dcps_all.idl
@@ -44,7 +43,7 @@ project (ddsx11_ndds_instancehandle_idl_gen) : install, \
   custom_only = 1
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
               -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
-              -Wb,post_include=idl/ndds_dcps_instance_handle.h -Scp -SS
+              -Wb,post_include=idl/ndds_dcps_instance_handle.h -Scp
 
   IDL_Files {
     ndds_dcps_instance_handle.idl
@@ -61,7 +60,7 @@ project (ddsx11_ndds_dcps_idl_gen) : install, \
   idlflags += -Wb,stub_export_macro=DDSX11_NDDS_STUB_Export \
               -Wb,stub_export_include=ddsx11_ndds_stub_export.h \
               -Wb,post_include=idl/dds_log_formatters.h \
-              -Glem -Gxhst -SS
+              -Glem -Gxhst
 
   // Make sure we first compile the vendor specific IDL
   after += ddsx11_ndds_types_idl_gen ddsx11_ndds_instancehandle_idl_gen ddsx11_ndds_dcps_all_idl_gen

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_all.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_all.idl
@@ -18,16 +18,6 @@
 #include "ndds_dcps_instance_handle.idl"
 #include "ndds_dcps_types.idl"
 
-#define TheParticipantFactory
-#define PARTICIPANT_QOS_DEFAULT
-#define TOPIC_QOS_DEFAULT
-#define PUBLISHER_QOS_DEFAULT
-#define SUBSCRIBER_QOS_DEFAULT
-#define DATAWRITER_QOS_DEFAULT
-#define DATAREADER_QOS_DEFAULT
-#define DATAWRITER_QOS_USE_TOPIC_QOS
-#define DATAREADER_QOS_USE_TOPIC_QOS
-
 module DDS {
 
     struct BuiltinTopicKey_t {

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_all.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_all.idl
@@ -19,1249 +19,1250 @@
 #include "ndds_dcps_types.idl"
 
 module DDS {
+  typedef unsigned long long_4[4];
 
-    struct BuiltinTopicKey_t {
-        /// RTI DDS specific
-        long_4 value;
-    };
-
-    typedef long ReturnCode_t;
-    typedef long QosPolicyId_t;
-
-    struct Duration_t {
-        long sec;
-        unsigned long nanosec;
-    };
-
-    struct Time_t {
-        long sec;
-        unsigned long nanosec;
-    };
-
-    typedef sequence<InstanceHandle_t> InstanceHandleSeq;
-
-    // ----------------------------------------------------------------------
-    // Pre-defined values
-    // ----------------------------------------------------------------------
-
-    const long LENGTH_UNLIMITED = -1;
-
-    const long            DURATION_INFINITE_SEC   = 0x7fffffff;
-    const unsigned long   DURATION_INFINITE_NSEC  = 0x7fffffff;
-
-    const long            DURATION_ZERO_SEC       = 0;
-    const unsigned long   DURATION_ZERO_NSEC      = 0;
-
-    const long            TIME_INVALID_SEC        = -1;
-    const unsigned long   TIME_INVALID_NSEC       = 0xffffffff;
-
-    // ----------------------------------------------------------------------
-    // Return codes
-    // ----------------------------------------------------------------------
-    const ReturnCode_t RETCODE_OK                    = 0;
-    const ReturnCode_t RETCODE_ERROR                 = 1;
-    const ReturnCode_t RETCODE_UNSUPPORTED           = 2;
-    const ReturnCode_t RETCODE_BAD_PARAMETER         = 3;
-    const ReturnCode_t RETCODE_PRECONDITION_NOT_MET  = 4;
-    const ReturnCode_t RETCODE_OUT_OF_RESOURCES      = 5;
-    const ReturnCode_t RETCODE_NOT_ENABLED           = 6;
-    const ReturnCode_t RETCODE_IMMUTABLE_POLICY      = 7;
-    const ReturnCode_t RETCODE_INCONSISTENT_POLICY   = 8;
-    const ReturnCode_t RETCODE_ALREADY_DELETED       = 9;
-    const ReturnCode_t RETCODE_TIMEOUT               = 10;
-    const ReturnCode_t RETCODE_NO_DATA               = 11;
-    const ReturnCode_t RETCODE_ILLEGAL_OPERATION     = 12;
-
-    // ----------------------------------------------------------------------
-    // Status to support listeners and conditions
-    // ----------------------------------------------------------------------
-
-    typedef unsigned long StatusKind;
-    typedef unsigned long StatusMask;    // bit-mask StatusKind
-    const StatusMask STATUS_MASK_NONE = 0;           // Empty mask
-    const StatusMask STATUS_MASK_ALL  = 0xffffffff;  // Mask with all bits set
-
-    const StatusKind INCONSISTENT_TOPIC_STATUS                = 0x0001 << 0;
-    const StatusKind OFFERED_DEADLINE_MISSED_STATUS           = 0x0001 << 1;
-    const StatusKind REQUESTED_DEADLINE_MISSED_STATUS         = 0x0001 << 2;
-    const StatusKind OFFERED_INCOMPATIBLE_QOS_STATUS          = 0x0001 << 5;
-    const StatusKind REQUESTED_INCOMPATIBLE_QOS_STATUS        = 0x0001 << 6;
-    const StatusKind SAMPLE_LOST_STATUS                       = 0x0001 << 7;
-    const StatusKind SAMPLE_REJECTED_STATUS                   = 0x0001 << 8;
-    const StatusKind DATA_ON_READERS_STATUS                   = 0x0001 << 9;
-    const StatusKind DATA_AVAILABLE_STATUS                    = 0x0001 << 10;
-    const StatusKind LIVELINESS_LOST_STATUS                   = 0x0001 << 11;
-    const StatusKind LIVELINESS_CHANGED_STATUS                = 0x0001 << 12;
-    const StatusKind PUBLICATION_MATCHED_STATUS               = 0x0001 << 13;
-    const StatusKind SUBSCRIPTION_MATCHED_STATUS              = 0x0001 << 14;
+  struct BuiltinTopicKey_t {
     /// RTI DDS specific
-    const StatusKind RELIABLE_WRITER_CACHE_CHANGED_STATUS     = 0x00000001 << 24;
-    /// RTI DDS specific
-    const StatusKind RELIABLE_READER_ACTIVITY_CHANGED_STATUS  = 0x00000001 << 25;
-
-    struct InconsistentTopicStatus {
-        long total_count;
-        long total_count_change;
-    };
-
-    /// Kinds of reasons why a sample was lost
-    /// RTI Specific extension
-    enum SampleLostStatusKind {
-      NOT_LOST,
-      LOST_BY_WRITER,
-      LOST_BY_INSTANCES_LIMIT,
-      LOST_BY_REMOTE_WRITERS_PER_INSTANCE_LIMIT,
-      LOST_BY_INCOMPLETE_COHERENT_SET,
-      LOST_BY_LARGE_COHERENT_SET,
-      LOST_BY_SAMPLES_PER_REMOTE_WRITER_LIMIT,
-      LOST_BY_VIRTUAL_WRITERS_LIMIT,
-      LOST_BY_REMOTE_WRITERS_PER_SAMPLE_LIMIT,
-      LOST_BY_AVAILABILITY_WAITING_TIME,
-      LOST_BY_REMOTE_WRITER_SAMPLES_PER_VIRTUAL_QUEUE_LIMIT,
-      LOST_BY_OUT_OF_MEMORY
-    };
-
-    struct SampleLostStatus {
-        long total_count;
-        long total_count_change;
-        /// RTI Extension
-        SampleLostStatusKind last_reason;
-    };
-
-    /// Kinds of reasons for rejecting a sample
-    enum SampleRejectedStatusKind {
-        NOT_REJECTED,
-        REJECTED_BY_INSTANCES_LIMIT,
-        REJECTED_BY_SAMPLES_LIMIT,
-        REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_REMOTE_WRITERS_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_REMOTE_WRITERS_PER_INSTANCE_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_SAMPLES_PER_REMOTE_WRITER_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_VIRTUAL_WRITERS_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_REMOTE_WRITERS_PER_SAMPLE_LIMIT,
-        /// RTI DDS specific
-        REJECTED_BY_REMOTE_WRITER_SAMPLES_PER_VIRTUAL_QUEUE_LIMIT
-    };
-
-    struct SampleRejectedStatus {
-        long                         total_count;
-        long                         total_count_change;
-        SampleRejectedStatusKind     last_reason;
-        InstanceHandle_t             last_instance_handle;
-    };
-
-    struct LivelinessLostStatus {
-        long                 total_count;
-        long                 total_count_change;
-    };
-
-    struct LivelinessChangedStatus {
-        long                 alive_count;
-        long                 not_alive_count;
-        long                 alive_count_change;
-        long                 not_alive_count_change;
-        InstanceHandle_t     last_publication_handle;
-    };
-
-    struct OfferedDeadlineMissedStatus {
-        long                 total_count;
-        long                 total_count_change;
-        InstanceHandle_t     last_instance_handle;
-    };
-
-    struct RequestedDeadlineMissedStatus {
-        long                 total_count;
-        long                 total_count_change;
-        InstanceHandle_t     last_instance_handle;
-    };
-
-    struct QosPolicyCount {
-        QosPolicyId_t        policy_id;
-        long                 count;
-    };
-
-    typedef sequence<QosPolicyCount> QosPolicyCountSeq;
-
-    struct OfferedIncompatibleQosStatus {
-        long                 total_count;
-        long                 total_count_change;
-        QosPolicyId_t        last_policy_id;
-        QosPolicyCountSeq    policies;
-    };
-
-    struct RequestedIncompatibleQosStatus {
-        long                 total_count;
-        long                 total_count_change;
-        QosPolicyId_t        last_policy_id;
-        QosPolicyCountSeq    policies;
-    };
-
-    struct PublicationMatchedStatus {
-        long                 total_count;
-        long                 total_count_change;
-        long                 current_count;
-        long                 current_count_change;
-        InstanceHandle_t     last_subscription_handle;
-    };
-
-    struct SubscriptionMatchedStatus {
-        long                 total_count;
-        long                 total_count_change;
-        long                 current_count;
-        long                 current_count_change;
-        InstanceHandle_t     last_publication_handle;
-    };
-
-    /// RTI DDS specific
-    struct ReliableReaderActivityChangedStatus {
-        long                 active_count;
-        long                 inactive_count;
-        long                 active_count_change;
-        long                 inactive_count_change;
-        InstanceHandle_t     last_instance_handle;
-    };
-
-    /// RTI DDS specific
-    struct ReliableWriterCacheEventCount {
-        long                 total_count;
-        long                 total_count_change;
-    };
-
-    /// RTI DDS specific
-    struct ReliableWriterCacheChangedStatus {
-        ReliableWriterCacheEventCount       empty_reliable_writer_cache;
-        ReliableWriterCacheEventCount       full_reliable_writer_cache;
-        ReliableWriterCacheEventCount       low_watermark_reliable_writer_cache;
-        ReliableWriterCacheEventCount       high_watermark_reliable_writer_cache;
-        long                                unacknowledged_sample_count;
-        long                                unacknowledged_sample_count_peak;
-    };
-
-    /// RTI DDS specific
-    enum TypeConsistencyKind {
-      DISALLOW_TYPE_COERCION,
-      ALLOW_TYPE_COERCION
-    };
-
-    /// RTI DDS specific
-    struct TypeConsistencyEnforcementQosPolicy {
-      TypeConsistencyKind kind;
-    };
-
-    // ----------------------------------------------------------------------
-    // Listeners
-    // ----------------------------------------------------------------------
-
-    local interface Entity;
-    local interface TopicDescription;
-    local interface Topic;
-    local interface ContentFilteredTopic;
-    local interface MultiTopic;
-    local interface DataWriter;
-    local interface DataReader;
-    local interface Subscriber;
-    local interface Publisher;
-
-    typedef sequence<DataReader> DataReaderSeq;
-
-    local interface Listener {};
-
-    local interface TopicListener : Listener {
-        void on_inconsistent_topic(in Topic the_topic,
-            in InconsistentTopicStatus status);
-    };
-
-    local interface DataWriterListener : Listener {
-        void on_offered_deadline_missed(
-            in DataWriter writer,
-            in OfferedDeadlineMissedStatus status);
-        void on_offered_incompatible_qos(
-            in DataWriter writer,
-            in OfferedIncompatibleQosStatus status);
-        void on_liveliness_lost(
-            in DataWriter writer,
-            in LivelinessLostStatus status);
-        void on_publication_matched(
-            in DataWriter writer,
-            in PublicationMatchedStatus status);
-        /// RTI DDS specific
-        void on_reliable_writer_cache_changed (
-            in DataWriter writer,
-            in ReliableWriterCacheChangedStatus status);
-        /// RTI DDS specific
-        void on_reliable_reader_activity_changed (
-            in DataWriter writer,
-            in ReliableReaderActivityChangedStatus status);
-    };
-
-    local interface PublisherListener : DataWriterListener {
-    };
-
-    local interface DataReaderListener : Listener {
-        void on_requested_deadline_missed(
-            in DataReader the_reader,
-            in RequestedDeadlineMissedStatus status);
-        void on_requested_incompatible_qos(
-            in DataReader the_reader,
-            in RequestedIncompatibleQosStatus status);
-        void on_sample_rejected(
-            in DataReader the_reader,
-            in SampleRejectedStatus status);
-        void on_liveliness_changed(
-            in DataReader the_reader,
-            in LivelinessChangedStatus status);
-        void on_data_available(
-            in DataReader the_reader);
-        void on_subscription_matched(
-            in DataReader the_reader,
-            in SubscriptionMatchedStatus status);
-        void on_sample_lost(
-            in DataReader the_reader,
-            in SampleLostStatus status);
-    };
-
-    local interface SubscriberListener : DataReaderListener {
-        void on_data_on_readers(
-            in Subscriber the_subscriber);
-    };
-
-
-    local interface DomainParticipantListener : TopicListener,
-                                      PublisherListener,
-                                      SubscriberListener {
-    };
-
-
-    // ----------------------------------------------------------------------
-    // Conditions
-    // ----------------------------------------------------------------------
-
-    local interface Condition {
-        boolean get_trigger_value();
-    };
-
-    // Only used in the WaitSet. DDS4CCM doesn't use this sequence
-    // so leaving it for now. Issue #3420 has been created for this.
-    typedef sequence<Condition> ConditionSeq;
-
-    local interface WaitSet {
-        ReturnCode_t wait(
-            inout ConditionSeq active_conditions,
-            in Duration_t timeout);
-        ReturnCode_t attach_condition(
-            in Condition cond);
-        ReturnCode_t detach_condition(
-            in Condition cond);
-        ReturnCode_t get_conditions(
-            inout ConditionSeq attached_conditions);
-    };
-
-    local interface GuardCondition : Condition {
-        ReturnCode_t set_trigger_value(
-            in boolean value);
-    };
-
-    local interface StatusCondition : Condition {
-        StatusMask get_enabled_statuses();
-        ReturnCode_t set_enabled_statuses(
-            in StatusMask mask);
-        Entity get_entity();
-    };
-
-    /// Sample states to support reads
-    typedef unsigned long SampleStateKind;
-    const SampleStateKind READ_SAMPLE_STATE                     = 0x0001 << 0;
-    const SampleStateKind NOT_READ_SAMPLE_STATE                 = 0x0001 << 1;
-
-    /// This is a bit-mask SampleStateKind
-    typedef unsigned long SampleStateMask;
-    const SampleStateMask ANY_SAMPLE_STATE                      = 0xffff;
-
-    /// View states to support reads
-    typedef unsigned long ViewStateKind;
-    const ViewStateKind NEW_VIEW_STATE                          = 0x0001 << 0;
-    const ViewStateKind NOT_NEW_VIEW_STATE                      = 0x0001 << 1;
-
-    /// This is a bit-mask ViewStateKind
-    typedef unsigned long ViewStateMask;
-    const ViewStateMask ANY_VIEW_STATE                          = 0xffff;
-
-    /// Instance states to support reads
-    typedef unsigned long InstanceStateKind;
-    const InstanceStateKind ALIVE_INSTANCE_STATE                = 0x0001 << 0;
-    const InstanceStateKind NOT_ALIVE_DISPOSED_INSTANCE_STATE   = 0x0001 << 1;
-    const InstanceStateKind NOT_ALIVE_NO_WRITERS_INSTANCE_STATE = 0x0001 << 2;
-
-    /// This is a bit-mask InstanceStateKind
-    typedef unsigned long InstanceStateMask;
-    const InstanceStateMask ANY_INSTANCE_STATE                  = 0xffff;
-    const InstanceStateMask NOT_ALIVE_INSTANCE_STATE            = 0x006;
-
-    local interface ReadCondition : Condition {
-        SampleStateMask     get_sample_state_mask();
-        ViewStateMask       get_view_state_mask();
-        InstanceStateMask   get_instance_state_mask();
-        DataReader          get_datareader();
-    };
-
-    local interface QueryCondition : ReadCondition {
-        string         get_query_expression();
-        ReturnCode_t   get_query_parameters(
-            inout StringSeq query_parameters);
-        ReturnCode_t   set_query_parameters(
-            in StringSeq query_parameters);
-    };
-
-    // ----------------------------------------------------------------------
-    // Qos
-    // ----------------------------------------------------------------------
-    const string USERDATA_QOS_POLICY_NAME              = "UserData";
-    const string DURABILITY_QOS_POLICY_NAME            = "Durability";
-    const string PRESENTATION_QOS_POLICY_NAME          = "Presentation";
-    const string DEADLINE_QOS_POLICY_NAME              = "Deadline";
-    const string LATENCYBUDGET_QOS_POLICY_NAME         = "LatencyBudget";
-    const string OWNERSHIP_QOS_POLICY_NAME             = "Ownership";
-    const string OWNERSHIPSTRENGTH_QOS_POLICY_NAME     = "OwnershipStrength";
-    const string LIVELINESS_QOS_POLICY_NAME            = "Liveliness";
-    const string TIMEBASEDFILTER_QOS_POLICY_NAME       = "TimeBasedFilter";
-    const string PARTITION_QOS_POLICY_NAME             = "Partition";
-    const string RELIABILITY_QOS_POLICY_NAME           = "Reliability";
-    const string DESTINATIONORDER_QOS_POLICY_NAME      = "DestinationOrder";
-    const string HISTORY_QOS_POLICY_NAME               = "History";
-    const string RESOURCELIMITS_QOS_POLICY_NAME        = "ResourceLimits";
-    const string ENTITYFACTORY_QOS_POLICY_NAME         = "EntityFactory";
-    const string WRITERDATALIFECYCLE_QOS_POLICY_NAME   = "WriterDataLifecycle";
-    const string READERDATALIFECYCLE_QOS_POLICY_NAME   = "ReaderDataLifecycle";
-    const string TOPICDATA_QOS_POLICY_NAME             = "TopicData";
-    const string GROUPDATA_QOS_POLICY_NAME             = "TransportPriority";
-    const string LIFESPAN_QOS_POLICY_NAME              = "Lifespan";
-    const string DURABILITYSERVICE_POLICY_NAME         = "DurabilityService";
-
-    const QosPolicyId_t INVALID_QOS_POLICY_ID              = 0;
-    const QosPolicyId_t USERDATA_QOS_POLICY_ID             = 1;
-    const QosPolicyId_t DURABILITY_QOS_POLICY_ID           = 2;
-    const QosPolicyId_t PRESENTATION_QOS_POLICY_ID         = 3;
-    const QosPolicyId_t DEADLINE_QOS_POLICY_ID             = 4;
-    const QosPolicyId_t LATENCYBUDGET_QOS_POLICY_ID        = 5;
-    const QosPolicyId_t OWNERSHIP_QOS_POLICY_ID            = 6;
-    const QosPolicyId_t OWNERSHIPSTRENGTH_QOS_POLICY_ID    = 7;
-    const QosPolicyId_t LIVELINESS_QOS_POLICY_ID           = 8;
-    const QosPolicyId_t TIMEBASEDFILTER_QOS_POLICY_ID      = 9;
-    const QosPolicyId_t PARTITION_QOS_POLICY_ID            = 10;
-    const QosPolicyId_t RELIABILITY_QOS_POLICY_ID          = 11;
-    const QosPolicyId_t DESTINATIONORDER_QOS_POLICY_ID     = 12;
-    const QosPolicyId_t HISTORY_QOS_POLICY_ID              = 13;
-    const QosPolicyId_t RESOURCELIMITS_QOS_POLICY_ID       = 14;
-    const QosPolicyId_t ENTITYFACTORY_QOS_POLICY_ID        = 15;
-    const QosPolicyId_t WRITERDATALIFECYCLE_QOS_POLICY_ID  = 16;
-    const QosPolicyId_t READERDATALIFECYCLE_QOS_POLICY_ID  = 17;
-    const QosPolicyId_t TOPICDATA_QOS_POLICY_ID            = 18;
-    const QosPolicyId_t GROUPDATA_QOS_POLICY_ID            = 19;
-    const QosPolicyId_t TRANSPORTPRIORITY_QOS_POLICY_ID    = 20;
-    const QosPolicyId_t LIFESPAN_QOS_POLICY_ID             = 21;
-    const QosPolicyId_t DURABILITYSERVICE_QOS_POLICY_ID    = 22;
-
-    /// RTI DDS specific.
-    const QosPolicyId_t TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID = 24;
-
-    /* --- Extension QoS policies: --- */
-    /// RTI DDS specific.
-    const QosPolicyId_t WIREPROTOCOL_QOS_POLICY_ID                    = 1000;
-    /// RTI DDS specific.
-    const QosPolicyId_t DISCOVERY_QOS_POLICY_ID                       = 1001;
-    /// RTI DDS specific.
-    const QosPolicyId_t DATAREADERRESOURCELIMITS_QOS_POLICY_ID        = 1003;
-    /// RTI DDS specific.
-    const QosPolicyId_t DATAWRITERRESOURCELIMITS_QOS_POLICY_ID        = 1004;
-    /// RTI DDS specific.
-    const QosPolicyId_t DATAREADERPROTOCOL_QOS_POLICY_ID              = 1005;
-    /// RTI DDS specific.
-    const QosPolicyId_t DATAWRITERPROTOCOL_QOS_POLICY_ID              = 1006;
-    /// RTI DDS specific.
-    const QosPolicyId_t DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID = 1007;
-    /// RTI DDS specific.
-    const QosPolicyId_t EVENT_QOS_POLICY_ID                           = 1008;
-    /// RTI DDS specific.
-    const QosPolicyId_t DATABASE_QOS_POLICY_ID                        = 1009;
-    /// RTI DDS specific.
-    const QosPolicyId_t RECEIVERPOOL_QOS_POLICY_ID                    = 1010;
-    /// RTI DDS specific.
-    const QosPolicyId_t DISCOVERYCONFIG_QOS_POLICY_ID                 = 1011;
-    /// RTI DDS specific.
-    const QosPolicyId_t EXCLUSIVEAREA_QOS_POLICY_ID                   = 1012;
-    /// RTI DDS specific.
-    const QosPolicyId_t USEROBJECT_QOS_POLICY_ID                      = 1013;
-    /// RTI DDS specific.
-    const QosPolicyId_t SYSTEMRESOURCELIMITS_QOS_POLICY_ID            = 1014;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTSELECTION_QOS_POLICY_ID              = 1015;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTUNICAST_QOS_POLICY_ID                = 1016;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTMULTICAST_QOS_POLICY_ID              = 1017;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTBUILTIN_QOS_POLICY_ID                = 1018;
-    /// RTI DDS specific.
-    const QosPolicyId_t TYPESUPPORT_QOS_POLICY_ID                     = 1019;
-    /// RTI DDS specific.
-    const QosPolicyId_t PROPERTY_QOS_POLICY_ID                        = 1020;
-    /// RTI DDS specific.
-    const QosPolicyId_t PUBLISHMODE_QOS_POLICY_ID                     = 1021;
-    /// RTI DDS specific.
-    const QosPolicyId_t ASYNCHRONOUSPUBLISHER_QOS_POLICY_ID           = 1022;
-    /// RTI DDS specific.
-    const QosPolicyId_t ENTITYNAME_QOS_POLICY_ID                      = 1023;
-    /// RTI DDS specific.
-    const QosPolicyId_t SERVICE_QOS_POLICY_ID                         = 1025;
-    /// RTI DDS specific.
-    const QosPolicyId_t BATCH_QOS_POLICY_ID                           = 1026;
-    /// RTI DDS specific.
-    const QosPolicyId_t PROFILE_QOS_POLICY_ID                         = 1027;
-    /// RTI DDS specific.
-    const QosPolicyId_t LOCATORFILTER_QOS_POLICY_ID                   = 1028;
-    /// RTI DDS specific.
-    const QosPolicyId_t MULTICHANNEL_QOS_POLICY_ID                    = 1029;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTENCAPSULATION_QOS_POLICY_ID          = 1030;
-    /// RTI DDS specific.
-    const QosPolicyId_t PUBLISHERPROTOCOL_QOS_POLICY_ID               = 1031;
-    /// RTI DDS specific.
-    const QosPolicyId_t SUBSCRIBERPROTOCOL_QOS_POLICY_ID              = 1032;
-    /// RTI DDS specific.
-    const QosPolicyId_t TOPICPROTOCOL_QOS_POLICY_ID                   = 1033;
-    /// RTI DDS specific.
-    const QosPolicyId_t DOMAINPARTICIPANTPROTOCOL_QOS_POLICY_ID       = 1034;
-    /// RTI DDS specific.
-    const QosPolicyId_t AVAILABILITY_QOS_POLICY_ID                    = 1035;
-    /// RTI DDS specific.
-    const QosPolicyId_t TRANSPORTMULTICASTMAPPING_QOS_POLICY_ID       = 1036;
-    /// RTI DDS specific.
-    const QosPolicyId_t LOGGING_QOS_POLICY_ID                         = 1037;
-
-    typedef sequence<octet> OctetSeq;
-
-    struct UserDataQosPolicy {
-        OctetSeq value;
-    };
-
-    struct TopicDataQosPolicy {
-        OctetSeq value;
-    };
-
-    struct GroupDataQosPolicy {
-        OctetSeq value;
-    };
-
-    struct TransportPriorityQosPolicy {
-        long value;
-    };
-
-    struct LifespanQosPolicy {
-        Duration_t duration;
-    };
-
-    enum DurabilityQosPolicyKind {
-        VOLATILE_DURABILITY_QOS,
-        TRANSIENT_LOCAL_DURABILITY_QOS,
-        TRANSIENT_DURABILITY_QOS,
-        PERSISTENT_DURABILITY_QOS
-    };
-    struct DurabilityQosPolicy {
-        DurabilityQosPolicyKind kind;
-    };
-
-    enum PresentationQosPolicyAccessScopeKind {
-        INSTANCE_PRESENTATION_QOS,
-        TOPIC_PRESENTATION_QOS,
-        GROUP_PRESENTATION_QOS,
-        /// RTI DDS specific
-        HIGHEST_OFFERED_PRESENTATION_QOS
-    };
-
-    struct PresentationQosPolicy {
-        PresentationQosPolicyAccessScopeKind access_scope;
-        boolean coherent_access;
-        boolean ordered_access;
-    };
-
-    struct DeadlineQosPolicy {
-        Duration_t period;
-    };
-
-    struct LatencyBudgetQosPolicy {
-        Duration_t duration;
-    };
-
-    enum OwnershipQosPolicyKind {
-        SHARED_OWNERSHIP_QOS,
-        EXCLUSIVE_OWNERSHIP_QOS
-    };
-
-    struct OwnershipQosPolicy {
-        OwnershipQosPolicyKind kind;
-    };
-
-    struct OwnershipStrengthQosPolicy {
-        long value;
-    };
-
-    enum LivelinessQosPolicyKind {
-        AUTOMATIC_LIVELINESS_QOS,
-        MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
-        MANUAL_BY_TOPIC_LIVELINESS_QOS
-    };
-
-    struct LivelinessQosPolicy {
-        LivelinessQosPolicyKind kind;
-        Duration_t lease_duration;
-    };
-
-    struct TimeBasedFilterQosPolicy {
-        Duration_t minimum_separation;
-    };
-
-    struct PartitionQosPolicy {
-        StringSeq name;
-    };
-
-    enum ReliabilityQosPolicyKind {
-        BEST_EFFORT_RELIABILITY_QOS,
-        RELIABLE_RELIABILITY_QOS
-    };
-
-    struct ReliabilityQosPolicy {
-        ReliabilityQosPolicyKind kind;
-        Duration_t max_blocking_time;
-    };
-
-    enum DestinationOrderQosPolicyKind {
-        BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
-        BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
-    };
-
-    /// RTI DDS specific
-    enum DestinationOrderQosPolicyScopeKind {
-        INSTANCE_SCOPE_DESTINATIONORDER_QOS,
-        TOPIC_SCOPE_DESTINATIONORDER_QOS
-    };
-
-    /// RTI DDS specific
-    enum DataWriterResourceLimitsInstanceReplacementKind {
-      UNREGISTERED_INSTANCE_REPLACEMENT,
-      ALIVE_INSTANCE_REPLACEMENT,
-      DISPOSED_INSTANCE_REPLACEMENT,
-      ALIVE_THEN_DISPOSED_INSTANCE_REPLACEMENT,
-      DISPOSED_THEN_ALIVE_INSTANCE_REPLACEMENT,
-      ALIVE_OR_DISPOSED_INSTANCE_REPLACEMENT
-    };
-
-    struct DestinationOrderQosPolicy {
-        DestinationOrderQosPolicyKind kind;
-        /// RTI DDS specific
-        DestinationOrderQosPolicyScopeKind scope;
-        /// RTI DDS specific
-        Duration_t source_timestamp_tolerance;
-    };
-
-    enum HistoryQosPolicyKind {
-        KEEP_LAST_HISTORY_QOS,
-        KEEP_ALL_HISTORY_QOS
-    };
-
-    /// RTI DDS specific
-    enum RefilterQosPolicyKind {
-        NONE_REFILTER_QOS,
-        ALL_REFILTER_QOS,
-        ON_DEMAND_REFILTER_QOS
-    };
-
-    struct HistoryQosPolicy {
-        HistoryQosPolicyKind kind;
-        long depth;
-        /// RTI DDS specific
-        RefilterQosPolicyKind refilter;
-    };
-
-    struct ResourceLimitsQosPolicy {
-        long max_samples;
-        long max_instances;
-        long max_samples_per_instance;
-        /// RTI DDS specific
-        long initial_samples;
-        /// RTI DDS specific
-        long initial_instances;
-        /// RTI DDS specific
-        long instance_hash_buckets;
-    };
-
-    struct EntityFactoryQosPolicy {
-        boolean autoenable_created_entities;
-    };
-
-    struct WriterDataLifecycleQosPolicy {
-        boolean autodispose_unregistered_instances;
-    };
-
-    /// RTI DDS specific
-    struct DataReaderResourceLimitsQosPolicy {
-      long max_remote_writers;
-      long max_remote_writers_per_instance;
-      long max_samples_per_remote_writer;
-      long max_infos;
-      long initial_remote_writers;
-      long initial_remote_writers_per_instance;
-      long initial_infos;
-      long initial_outstanding_reads;
-      long max_outstanding_reads;
-      long max_samples_per_read;
-      boolean disable_fragmentation_support;
-      long max_fragmented_samples;
-      long initial_fragmented_samples;
-      long max_fragmented_samples_per_remote_writer;
-      long max_fragments_per_sample;
-      boolean dynamically_allocate_fragmented_samples;
-      long max_total_instances;
-      long max_remote_virtual_writers_per_instance;
-      long initial_remote_virtual_writers_per_instance;
-      long max_query_condition_filters;
-    };
-
-    /// RTI DDS specific
-    struct DataWriterResourceLimitsQosPolicy {
-      long initial_concurrent_blocking_threads;
-      long max_concurrent_blocking_threads;
-      long max_remote_reader_filters;
-      long initial_batches;
-      long max_batches;
-      long cookie_max_length;
-      DataWriterResourceLimitsInstanceReplacementKind instance_replacement;
-      boolean replace_empty_instances;
-      boolean autoregister_instances;
-    };
-
-    struct ReaderDataLifecycleQosPolicy {
-        Duration_t autopurge_nowriter_samples_delay;
-        Duration_t autopurge_disposed_samples_delay;
-    };
-
-    struct DurabilityServiceQosPolicy {
-        Duration_t              service_cleanup_delay;
-        HistoryQosPolicyKind    history_kind;
-        long                    history_depth;
-        long                    max_samples;
-        long                    max_instances;
-        long                    max_samples_per_instance;
-    };
-
-    struct DomainParticipantFactoryQos {
-        EntityFactoryQosPolicy entity_factory;
-    };
-
-    struct DomainParticipantQos {
-        UserDataQosPolicy  user_data;
-        EntityFactoryQosPolicy entity_factory;
-    };
-
-    struct TopicQos {
-        TopicDataQosPolicy                   topic_data;
-        DurabilityQosPolicy                  durability;
-        DurabilityServiceQosPolicy           durability_service;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        DestinationOrderQosPolicy            destination_order;
-        HistoryQosPolicy                     history;
-        ResourceLimitsQosPolicy              resource_limits;
-        TransportPriorityQosPolicy           transport_priority;
-        LifespanQosPolicy                    lifespan;
-
-        OwnershipQosPolicy                   ownership;
-    };
-
-    struct DataWriterQos {
-        DurabilityQosPolicy                  durability;
-        DurabilityServiceQosPolicy           durability_service;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        DestinationOrderQosPolicy            destination_order;
-        HistoryQosPolicy                     history;
-        ResourceLimitsQosPolicy              resource_limits;
-        TransportPriorityQosPolicy           transport_priority;
-        LifespanQosPolicy                    lifespan;
-
-        UserDataQosPolicy                    user_data;
-        OwnershipQosPolicy                   ownership;
-        OwnershipStrengthQosPolicy           ownership_strength;
-        WriterDataLifecycleQosPolicy         writer_data_lifecycle;
-
-        /// RTI DDS specific
-        DataWriterResourceLimitsQosPolicy    writer_resource_limits;
-    };
-
-    struct PublisherQos {
-        PresentationQosPolicy                presentation;
-        PartitionQosPolicy                   partition;
-        GroupDataQosPolicy                   group_data;
-        EntityFactoryQosPolicy               entity_factory;
-    };
-
-    struct DataReaderQos {
-        DurabilityQosPolicy                  durability;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        DestinationOrderQosPolicy            destination_order;
-        HistoryQosPolicy                     history;
-        ResourceLimitsQosPolicy              resource_limits;
-
-        UserDataQosPolicy                    user_data;
-        OwnershipQosPolicy                   ownership;
-        TimeBasedFilterQosPolicy             time_based_filter;
-        ReaderDataLifecycleQosPolicy         reader_data_lifecycle;
-
-        /// RTI DDS specific
-        DataReaderResourceLimitsQosPolicy    reader_resource_limits;
-
-        /// RTI DDS specific
-        TypeConsistencyEnforcementQosPolicy  type_consistency;
-    };
-
-    struct SubscriberQos {
-        PresentationQosPolicy                presentation;
-        PartitionQosPolicy                   partition;
-        GroupDataQosPolicy                   group_data;
-        EntityFactoryQosPolicy               entity_factory;
-    };
-
-    // ----------------------------------------------------------------------
-
-    struct ParticipantBuiltinTopicData {
-        BuiltinTopicKey_t                    key;
-        UserDataQosPolicy                    user_data;
-    };
-
-    struct TopicBuiltinTopicData {
-        BuiltinTopicKey_t                    key;
-        string                               name;
-        string                               type_name;
-        DurabilityQosPolicy                  durability;
-        DurabilityServiceQosPolicy           durability_service;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        TransportPriorityQosPolicy           transport_priority;
-        LifespanQosPolicy                    lifespan;
-        DestinationOrderQosPolicy            destination_order;
-        HistoryQosPolicy                     history;
-        ResourceLimitsQosPolicy              resource_limits;
-        OwnershipQosPolicy                   ownership;
-        TopicDataQosPolicy                   topic_data;
-    };
-
-    struct PublicationBuiltinTopicData {
-        BuiltinTopicKey_t                    key;
-        BuiltinTopicKey_t                    participant_key;
-        string                               topic_name;
-        string                               type_name;
-
-        DurabilityQosPolicy                  durability;
-        DurabilityServiceQosPolicy           durability_service;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        LifespanQosPolicy                    lifespan;
-        UserDataQosPolicy                    user_data;
-        OwnershipQosPolicy                   ownership;
-        OwnershipStrengthQosPolicy           ownership_strength;
-        DestinationOrderQosPolicy            destination_order;
-
-        PresentationQosPolicy                presentation;
-        PartitionQosPolicy                   partition;
-        TopicDataQosPolicy                   topic_data;
-        GroupDataQosPolicy                   group_data;
-    };
-
-    struct SubscriptionBuiltinTopicData {
-        BuiltinTopicKey_t                    key;
-        BuiltinTopicKey_t                    participant_key;
-        string                               topic_name;
-        string                               type_name;
-
-        DurabilityQosPolicy                  durability;
-        DeadlineQosPolicy                    deadline;
-        LatencyBudgetQosPolicy               latency_budget;
-        LivelinessQosPolicy                  liveliness;
-        ReliabilityQosPolicy                 reliability;
-        OwnershipQosPolicy                   ownership;
-        DestinationOrderQosPolicy            destination_order;
-        UserDataQosPolicy                    user_data;
-        TimeBasedFilterQosPolicy             time_based_filter;
-
-        PresentationQosPolicy                presentation;
-        PartitionQosPolicy                   partition;
-        TopicDataQosPolicy                   topic_data;
-        GroupDataQosPolicy                   group_data;
-    };
-
-    // ----------------------------------------------------------------------
-
-    local interface Entity {
-    //  ReturnCode_t set_qos(
-    //      in EntityQos qos);
-    //  ReturnCode_t get_qos(
-    //      inout EntityQos qos);
-    //  ReturnCode_t set_listener(
-    //      in Listener l,
-    //      in StatusMask mask);
-    //  Listener get_listener();
-
-        ReturnCode_t enable();
-
-        StatusCondition get_statuscondition();
-
-        StatusMask get_status_changes();
-
-        InstanceHandle_t get_instance_handle();
-    };
-
-    local interface DomainParticipant : Entity {
-        // Factory interfaces
-        Publisher create_publisher(
-            in PublisherQos qos,
-            in PublisherListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        Publisher create_publisher_with_profile(
-            in string qos_profile,
-            in PublisherListener a_listener,
-            in StatusMask mask);
-        ReturnCode_t delete_publisher(
-            in Publisher p);
-
-        Subscriber create_subscriber(
-            in SubscriberQos qos,
-            in SubscriberListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        Subscriber create_subscriber_with_profile(
-            in string qos_profile,
-            in SubscriberListener a_listener,
-            in StatusMask mask);
-        ReturnCode_t delete_subscriber(
-            in Subscriber s);
-        Subscriber get_builtin_subscriber();
-
-        Topic create_topic(
-            in string topic_name,
-            in string type_name,
-            in TopicQos qos,
-            in TopicListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        Topic create_topic_with_profile(
-            in string topic_name,
-            in string type_name,
-            in string qos_profile,
-            in TopicListener a_listener,
-            in StatusMask mask);
-
-        ReturnCode_t delete_topic(
-            in Topic a_topic);
-
-        Topic find_topic(
-            in string topic_name,
-            in Duration_t timeout);
-        TopicDescription lookup_topicdescription(
-            in string name);
-
-        ContentFilteredTopic create_contentfilteredtopic(
-            in string name,
-            in Topic related_topic,
-            in string filter_expression,
-            in StringSeq expression_parameters);
-
-        ReturnCode_t delete_contentfilteredtopic(
-            in ContentFilteredTopic a_contentfilteredtopic);
-
-        MultiTopic create_multitopic(
-            in string name,
-            in string type_name,
-            in string subscription_expression,
-            in StringSeq expression_parameters);
-
-        ReturnCode_t delete_multitopic(
-            in MultiTopic a_multitopic);
-
-        ReturnCode_t delete_contained_entities();
-
-        ReturnCode_t set_qos(
-            in DomainParticipantQos qos);
-        ReturnCode_t get_qos(
-            inout DomainParticipantQos qos);
-
-        ReturnCode_t set_listener(
-            in DomainParticipantListener a_listener,
-            in StatusMask mask);
-        DomainParticipantListener get_listener();
-
-        ReturnCode_t ignore_participant(
-            in InstanceHandle_t handle);
-        ReturnCode_t ignore_topic(
-            in InstanceHandle_t handle);
-        ReturnCode_t ignore_publication(
-            in InstanceHandle_t handle);
-        ReturnCode_t ignore_subscription(
-            in InstanceHandle_t handle);
-
-        DomainId_t get_domain_id();
-        ReturnCode_t assert_liveliness();
-
-        ReturnCode_t set_default_publisher_qos(
-            in PublisherQos qos);
-        ReturnCode_t get_default_publisher_qos(
-            inout PublisherQos qos);
-
-        ReturnCode_t set_default_subscriber_qos(
-            in SubscriberQos qos);
-        ReturnCode_t get_default_subscriber_qos(
-            inout SubscriberQos qos);
-
-        ReturnCode_t set_default_topic_qos(
-            in TopicQos qos);
-        ReturnCode_t get_default_topic_qos(
-            inout TopicQos qos);
-
-        ReturnCode_t get_discovered_participants(
-            inout InstanceHandleSeq participant_handles);
-        ReturnCode_t get_discovered_participant_data(
-            inout ParticipantBuiltinTopicData participant_data,
-            in InstanceHandle_t participant_handle);
-
-        ReturnCode_t get_discovered_topics(
-            inout InstanceHandleSeq topic_handles);
-        ReturnCode_t get_discovered_topic_data(
-            inout TopicBuiltinTopicData topic_data,
-            in InstanceHandle_t topic_handle);
-
-        boolean contains_entity(
-            in InstanceHandle_t a_handle);
-
-        ReturnCode_t get_current_time(
-            inout Time_t current_time);
-    };
-
-    local interface DomainParticipantFactory {
-        DomainParticipant create_participant(
-            in DomainId_t domain_id,
-            in DomainParticipantQos qos,
-            in DomainParticipantListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        DomainParticipant create_participant_with_profile(
-            in DomainId_t domain_id,
-            in string qos_profile,
-            in DomainParticipantListener a_listener,
-            in StatusMask mask);
-        ReturnCode_t delete_participant(
-            in DomainParticipant a_participant);
-
-        DomainParticipant lookup_participant(
-            in DomainId_t domain_id);
-
-        ReturnCode_t set_default_participant_qos(
-            in DomainParticipantQos qos);
-        /// RTI DDS specific
-        ReturnCode_t set_default_participant_qos_with_profile(
-            in string qos_profile);
-        ReturnCode_t get_default_participant_qos(
-            inout DomainParticipantQos qos);
-
-        ReturnCode_t set_qos(
-            in DomainParticipantFactoryQos qos);
-        ReturnCode_t get_qos(
-            inout DomainParticipantFactoryQos qos);
-
-        // Extension to nicely close the domain participant factory
-        ReturnCode_t finalize_instance ();
-    };
-
-    local interface TypeSupport {
-         ReturnCode_t register_type(
-             in DomainParticipant domain,
-             in string type_name);
-         ReturnCode_t unregister_type(
-             in DomainParticipant domain,
-             in string type_name);
-         string get_type_name();
-    };
-
-    // ----------------------------------------------------------------------
-    local interface TopicDescription {
+    long_4 value;
+  };
+
+  typedef long ReturnCode_t;
+  typedef long QosPolicyId_t;
+
+  struct Duration_t {
+    long sec;
+    unsigned long nanosec;
+  };
+
+  struct Time_t {
+      long sec;
+      unsigned long nanosec;
+  };
+
+  typedef sequence<InstanceHandle_t> InstanceHandleSeq;
+
+  // ----------------------------------------------------------------------
+  // Pre-defined values
+  // ----------------------------------------------------------------------
+
+  const long LENGTH_UNLIMITED = -1;
+
+  const long            DURATION_INFINITE_SEC   = 0x7fffffff;
+  const unsigned long   DURATION_INFINITE_NSEC  = 0x7fffffff;
+
+  const long            DURATION_ZERO_SEC       = 0;
+  const unsigned long   DURATION_ZERO_NSEC      = 0;
+
+  const long            TIME_INVALID_SEC        = -1;
+  const unsigned long   TIME_INVALID_NSEC       = 0xffffffff;
+
+  // ----------------------------------------------------------------------
+  // Return codes
+  // ----------------------------------------------------------------------
+  const ReturnCode_t RETCODE_OK                    = 0;
+  const ReturnCode_t RETCODE_ERROR                 = 1;
+  const ReturnCode_t RETCODE_UNSUPPORTED           = 2;
+  const ReturnCode_t RETCODE_BAD_PARAMETER         = 3;
+  const ReturnCode_t RETCODE_PRECONDITION_NOT_MET  = 4;
+  const ReturnCode_t RETCODE_OUT_OF_RESOURCES      = 5;
+  const ReturnCode_t RETCODE_NOT_ENABLED           = 6;
+  const ReturnCode_t RETCODE_IMMUTABLE_POLICY      = 7;
+  const ReturnCode_t RETCODE_INCONSISTENT_POLICY   = 8;
+  const ReturnCode_t RETCODE_ALREADY_DELETED       = 9;
+  const ReturnCode_t RETCODE_TIMEOUT               = 10;
+  const ReturnCode_t RETCODE_NO_DATA               = 11;
+  const ReturnCode_t RETCODE_ILLEGAL_OPERATION     = 12;
+
+  // ----------------------------------------------------------------------
+  // Status to support listeners and conditions
+  // ----------------------------------------------------------------------
+
+  typedef unsigned long StatusKind;
+  typedef unsigned long StatusMask;    // bit-mask StatusKind
+  const StatusMask STATUS_MASK_NONE = 0;           // Empty mask
+  const StatusMask STATUS_MASK_ALL  = 0xffffffff;  // Mask with all bits set
+
+  const StatusKind INCONSISTENT_TOPIC_STATUS                = 0x0001 << 0;
+  const StatusKind OFFERED_DEADLINE_MISSED_STATUS           = 0x0001 << 1;
+  const StatusKind REQUESTED_DEADLINE_MISSED_STATUS         = 0x0001 << 2;
+  const StatusKind OFFERED_INCOMPATIBLE_QOS_STATUS          = 0x0001 << 5;
+  const StatusKind REQUESTED_INCOMPATIBLE_QOS_STATUS        = 0x0001 << 6;
+  const StatusKind SAMPLE_LOST_STATUS                       = 0x0001 << 7;
+  const StatusKind SAMPLE_REJECTED_STATUS                   = 0x0001 << 8;
+  const StatusKind DATA_ON_READERS_STATUS                   = 0x0001 << 9;
+  const StatusKind DATA_AVAILABLE_STATUS                    = 0x0001 << 10;
+  const StatusKind LIVELINESS_LOST_STATUS                   = 0x0001 << 11;
+  const StatusKind LIVELINESS_CHANGED_STATUS                = 0x0001 << 12;
+  const StatusKind PUBLICATION_MATCHED_STATUS               = 0x0001 << 13;
+  const StatusKind SUBSCRIPTION_MATCHED_STATUS              = 0x0001 << 14;
+  /// RTI DDS specific
+  const StatusKind RELIABLE_WRITER_CACHE_CHANGED_STATUS     = 0x00000001 << 24;
+  /// RTI DDS specific
+  const StatusKind RELIABLE_READER_ACTIVITY_CHANGED_STATUS  = 0x00000001 << 25;
+
+  struct InconsistentTopicStatus {
+      long total_count;
+      long total_count_change;
+  };
+
+  /// Kinds of reasons why a sample was lost
+  /// RTI Specific extension
+  enum SampleLostStatusKind {
+    NOT_LOST,
+    LOST_BY_WRITER,
+    LOST_BY_INSTANCES_LIMIT,
+    LOST_BY_REMOTE_WRITERS_PER_INSTANCE_LIMIT,
+    LOST_BY_INCOMPLETE_COHERENT_SET,
+    LOST_BY_LARGE_COHERENT_SET,
+    LOST_BY_SAMPLES_PER_REMOTE_WRITER_LIMIT,
+    LOST_BY_VIRTUAL_WRITERS_LIMIT,
+    LOST_BY_REMOTE_WRITERS_PER_SAMPLE_LIMIT,
+    LOST_BY_AVAILABILITY_WAITING_TIME,
+    LOST_BY_REMOTE_WRITER_SAMPLES_PER_VIRTUAL_QUEUE_LIMIT,
+    LOST_BY_OUT_OF_MEMORY
+  };
+
+  struct SampleLostStatus {
+      long total_count;
+      long total_count_change;
+      /// RTI Extension
+      SampleLostStatusKind last_reason;
+  };
+
+  /// Kinds of reasons for rejecting a sample
+  enum SampleRejectedStatusKind {
+      NOT_REJECTED,
+      REJECTED_BY_INSTANCES_LIMIT,
+      REJECTED_BY_SAMPLES_LIMIT,
+      REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_REMOTE_WRITERS_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_REMOTE_WRITERS_PER_INSTANCE_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_SAMPLES_PER_REMOTE_WRITER_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_VIRTUAL_WRITERS_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_REMOTE_WRITERS_PER_SAMPLE_LIMIT,
+      /// RTI DDS specific
+      REJECTED_BY_REMOTE_WRITER_SAMPLES_PER_VIRTUAL_QUEUE_LIMIT
+  };
+
+  struct SampleRejectedStatus {
+      long                         total_count;
+      long                         total_count_change;
+      SampleRejectedStatusKind     last_reason;
+      InstanceHandle_t             last_instance_handle;
+  };
+
+  struct LivelinessLostStatus {
+      long                 total_count;
+      long                 total_count_change;
+  };
+
+  struct LivelinessChangedStatus {
+      long                 alive_count;
+      long                 not_alive_count;
+      long                 alive_count_change;
+      long                 not_alive_count_change;
+      InstanceHandle_t     last_publication_handle;
+  };
+
+  struct OfferedDeadlineMissedStatus {
+      long                 total_count;
+      long                 total_count_change;
+      InstanceHandle_t     last_instance_handle;
+  };
+
+  struct RequestedDeadlineMissedStatus {
+      long                 total_count;
+      long                 total_count_change;
+      InstanceHandle_t     last_instance_handle;
+  };
+
+  struct QosPolicyCount {
+      QosPolicyId_t        policy_id;
+      long                 count;
+  };
+
+  typedef sequence<QosPolicyCount> QosPolicyCountSeq;
+
+  struct OfferedIncompatibleQosStatus {
+      long                 total_count;
+      long                 total_count_change;
+      QosPolicyId_t        last_policy_id;
+      QosPolicyCountSeq    policies;
+  };
+
+  struct RequestedIncompatibleQosStatus {
+      long                 total_count;
+      long                 total_count_change;
+      QosPolicyId_t        last_policy_id;
+      QosPolicyCountSeq    policies;
+  };
+
+  struct PublicationMatchedStatus {
+      long                 total_count;
+      long                 total_count_change;
+      long                 current_count;
+      long                 current_count_change;
+      InstanceHandle_t     last_subscription_handle;
+  };
+
+  struct SubscriptionMatchedStatus {
+      long                 total_count;
+      long                 total_count_change;
+      long                 current_count;
+      long                 current_count_change;
+      InstanceHandle_t     last_publication_handle;
+  };
+
+  /// RTI DDS specific
+  struct ReliableReaderActivityChangedStatus {
+      long                 active_count;
+      long                 inactive_count;
+      long                 active_count_change;
+      long                 inactive_count_change;
+      InstanceHandle_t     last_instance_handle;
+  };
+
+  /// RTI DDS specific
+  struct ReliableWriterCacheEventCount {
+      long                 total_count;
+      long                 total_count_change;
+  };
+
+  /// RTI DDS specific
+  struct ReliableWriterCacheChangedStatus {
+      ReliableWriterCacheEventCount       empty_reliable_writer_cache;
+      ReliableWriterCacheEventCount       full_reliable_writer_cache;
+      ReliableWriterCacheEventCount       low_watermark_reliable_writer_cache;
+      ReliableWriterCacheEventCount       high_watermark_reliable_writer_cache;
+      long                                unacknowledged_sample_count;
+      long                                unacknowledged_sample_count_peak;
+  };
+
+  /// RTI DDS specific
+  enum TypeConsistencyKind {
+    DISALLOW_TYPE_COERCION,
+    ALLOW_TYPE_COERCION
+  };
+
+  /// RTI DDS specific
+  struct TypeConsistencyEnforcementQosPolicy {
+    TypeConsistencyKind kind;
+  };
+
+  // ----------------------------------------------------------------------
+  // Listeners
+  // ----------------------------------------------------------------------
+
+  local interface Entity;
+  local interface TopicDescription;
+  local interface Topic;
+  local interface ContentFilteredTopic;
+  local interface MultiTopic;
+  local interface DataWriter;
+  local interface DataReader;
+  local interface Subscriber;
+  local interface Publisher;
+
+  typedef sequence<DataReader> DataReaderSeq;
+
+  local interface Listener {};
+
+  local interface TopicListener : Listener {
+      void on_inconsistent_topic(in Topic the_topic,
+          in InconsistentTopicStatus status);
+  };
+
+  local interface DataWriterListener : Listener {
+      void on_offered_deadline_missed(
+          in DataWriter writer,
+          in OfferedDeadlineMissedStatus status);
+      void on_offered_incompatible_qos(
+          in DataWriter writer,
+          in OfferedIncompatibleQosStatus status);
+      void on_liveliness_lost(
+          in DataWriter writer,
+          in LivelinessLostStatus status);
+      void on_publication_matched(
+          in DataWriter writer,
+          in PublicationMatchedStatus status);
+      /// RTI DDS specific
+      void on_reliable_writer_cache_changed (
+          in DataWriter writer,
+          in ReliableWriterCacheChangedStatus status);
+      /// RTI DDS specific
+      void on_reliable_reader_activity_changed (
+          in DataWriter writer,
+          in ReliableReaderActivityChangedStatus status);
+  };
+
+  local interface PublisherListener : DataWriterListener {
+  };
+
+  local interface DataReaderListener : Listener {
+      void on_requested_deadline_missed(
+          in DataReader the_reader,
+          in RequestedDeadlineMissedStatus status);
+      void on_requested_incompatible_qos(
+          in DataReader the_reader,
+          in RequestedIncompatibleQosStatus status);
+      void on_sample_rejected(
+          in DataReader the_reader,
+          in SampleRejectedStatus status);
+      void on_liveliness_changed(
+          in DataReader the_reader,
+          in LivelinessChangedStatus status);
+      void on_data_available(
+          in DataReader the_reader);
+      void on_subscription_matched(
+          in DataReader the_reader,
+          in SubscriptionMatchedStatus status);
+      void on_sample_lost(
+          in DataReader the_reader,
+          in SampleLostStatus status);
+  };
+
+  local interface SubscriberListener : DataReaderListener {
+      void on_data_on_readers(
+          in Subscriber the_subscriber);
+  };
+
+
+  local interface DomainParticipantListener : TopicListener,
+                                    PublisherListener,
+                                    SubscriberListener {
+  };
+
+
+  // ----------------------------------------------------------------------
+  // Conditions
+  // ----------------------------------------------------------------------
+
+  local interface Condition {
+      boolean get_trigger_value();
+  };
+
+  // Only used in the WaitSet. DDS4CCM doesn't use this sequence
+  // so leaving it for now. Issue #3420 has been created for this.
+  typedef sequence<Condition> ConditionSeq;
+
+  local interface WaitSet {
+      ReturnCode_t wait(
+          inout ConditionSeq active_conditions,
+          in Duration_t timeout);
+      ReturnCode_t attach_condition(
+          in Condition cond);
+      ReturnCode_t detach_condition(
+          in Condition cond);
+      ReturnCode_t get_conditions(
+          inout ConditionSeq attached_conditions);
+  };
+
+  local interface GuardCondition : Condition {
+      ReturnCode_t set_trigger_value(
+          in boolean value);
+  };
+
+  local interface StatusCondition : Condition {
+      StatusMask get_enabled_statuses();
+      ReturnCode_t set_enabled_statuses(
+          in StatusMask mask);
+      Entity get_entity();
+  };
+
+  /// Sample states to support reads
+  typedef unsigned long SampleStateKind;
+  const SampleStateKind READ_SAMPLE_STATE                     = 0x0001 << 0;
+  const SampleStateKind NOT_READ_SAMPLE_STATE                 = 0x0001 << 1;
+
+  /// This is a bit-mask SampleStateKind
+  typedef unsigned long SampleStateMask;
+  const SampleStateMask ANY_SAMPLE_STATE                      = 0xffff;
+
+  /// View states to support reads
+  typedef unsigned long ViewStateKind;
+  const ViewStateKind NEW_VIEW_STATE                          = 0x0001 << 0;
+  const ViewStateKind NOT_NEW_VIEW_STATE                      = 0x0001 << 1;
+
+  /// This is a bit-mask ViewStateKind
+  typedef unsigned long ViewStateMask;
+  const ViewStateMask ANY_VIEW_STATE                          = 0xffff;
+
+  /// Instance states to support reads
+  typedef unsigned long InstanceStateKind;
+  const InstanceStateKind ALIVE_INSTANCE_STATE                = 0x0001 << 0;
+  const InstanceStateKind NOT_ALIVE_DISPOSED_INSTANCE_STATE   = 0x0001 << 1;
+  const InstanceStateKind NOT_ALIVE_NO_WRITERS_INSTANCE_STATE = 0x0001 << 2;
+
+  /// This is a bit-mask InstanceStateKind
+  typedef unsigned long InstanceStateMask;
+  const InstanceStateMask ANY_INSTANCE_STATE                  = 0xffff;
+  const InstanceStateMask NOT_ALIVE_INSTANCE_STATE            = 0x006;
+
+  local interface ReadCondition : Condition {
+      SampleStateMask     get_sample_state_mask();
+      ViewStateMask       get_view_state_mask();
+      InstanceStateMask   get_instance_state_mask();
+      DataReader          get_datareader();
+  };
+
+  local interface QueryCondition : ReadCondition {
+      string         get_query_expression();
+      ReturnCode_t   get_query_parameters(
+          inout StringSeq query_parameters);
+      ReturnCode_t   set_query_parameters(
+          in StringSeq query_parameters);
+  };
+
+  // ----------------------------------------------------------------------
+  // Qos
+  // ----------------------------------------------------------------------
+  const string USERDATA_QOS_POLICY_NAME              = "UserData";
+  const string DURABILITY_QOS_POLICY_NAME            = "Durability";
+  const string PRESENTATION_QOS_POLICY_NAME          = "Presentation";
+  const string DEADLINE_QOS_POLICY_NAME              = "Deadline";
+  const string LATENCYBUDGET_QOS_POLICY_NAME         = "LatencyBudget";
+  const string OWNERSHIP_QOS_POLICY_NAME             = "Ownership";
+  const string OWNERSHIPSTRENGTH_QOS_POLICY_NAME     = "OwnershipStrength";
+  const string LIVELINESS_QOS_POLICY_NAME            = "Liveliness";
+  const string TIMEBASEDFILTER_QOS_POLICY_NAME       = "TimeBasedFilter";
+  const string PARTITION_QOS_POLICY_NAME             = "Partition";
+  const string RELIABILITY_QOS_POLICY_NAME           = "Reliability";
+  const string DESTINATIONORDER_QOS_POLICY_NAME      = "DestinationOrder";
+  const string HISTORY_QOS_POLICY_NAME               = "History";
+  const string RESOURCELIMITS_QOS_POLICY_NAME        = "ResourceLimits";
+  const string ENTITYFACTORY_QOS_POLICY_NAME         = "EntityFactory";
+  const string WRITERDATALIFECYCLE_QOS_POLICY_NAME   = "WriterDataLifecycle";
+  const string READERDATALIFECYCLE_QOS_POLICY_NAME   = "ReaderDataLifecycle";
+  const string TOPICDATA_QOS_POLICY_NAME             = "TopicData";
+  const string GROUPDATA_QOS_POLICY_NAME             = "TransportPriority";
+  const string LIFESPAN_QOS_POLICY_NAME              = "Lifespan";
+  const string DURABILITYSERVICE_POLICY_NAME         = "DurabilityService";
+
+  const QosPolicyId_t INVALID_QOS_POLICY_ID              = 0;
+  const QosPolicyId_t USERDATA_QOS_POLICY_ID             = 1;
+  const QosPolicyId_t DURABILITY_QOS_POLICY_ID           = 2;
+  const QosPolicyId_t PRESENTATION_QOS_POLICY_ID         = 3;
+  const QosPolicyId_t DEADLINE_QOS_POLICY_ID             = 4;
+  const QosPolicyId_t LATENCYBUDGET_QOS_POLICY_ID        = 5;
+  const QosPolicyId_t OWNERSHIP_QOS_POLICY_ID            = 6;
+  const QosPolicyId_t OWNERSHIPSTRENGTH_QOS_POLICY_ID    = 7;
+  const QosPolicyId_t LIVELINESS_QOS_POLICY_ID           = 8;
+  const QosPolicyId_t TIMEBASEDFILTER_QOS_POLICY_ID      = 9;
+  const QosPolicyId_t PARTITION_QOS_POLICY_ID            = 10;
+  const QosPolicyId_t RELIABILITY_QOS_POLICY_ID          = 11;
+  const QosPolicyId_t DESTINATIONORDER_QOS_POLICY_ID     = 12;
+  const QosPolicyId_t HISTORY_QOS_POLICY_ID              = 13;
+  const QosPolicyId_t RESOURCELIMITS_QOS_POLICY_ID       = 14;
+  const QosPolicyId_t ENTITYFACTORY_QOS_POLICY_ID        = 15;
+  const QosPolicyId_t WRITERDATALIFECYCLE_QOS_POLICY_ID  = 16;
+  const QosPolicyId_t READERDATALIFECYCLE_QOS_POLICY_ID  = 17;
+  const QosPolicyId_t TOPICDATA_QOS_POLICY_ID            = 18;
+  const QosPolicyId_t GROUPDATA_QOS_POLICY_ID            = 19;
+  const QosPolicyId_t TRANSPORTPRIORITY_QOS_POLICY_ID    = 20;
+  const QosPolicyId_t LIFESPAN_QOS_POLICY_ID             = 21;
+  const QosPolicyId_t DURABILITYSERVICE_QOS_POLICY_ID    = 22;
+
+  /// RTI DDS specific.
+  const QosPolicyId_t TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID = 24;
+
+  /* --- Extension QoS policies: --- */
+  /// RTI DDS specific.
+  const QosPolicyId_t WIREPROTOCOL_QOS_POLICY_ID                    = 1000;
+  /// RTI DDS specific.
+  const QosPolicyId_t DISCOVERY_QOS_POLICY_ID                       = 1001;
+  /// RTI DDS specific.
+  const QosPolicyId_t DATAREADERRESOURCELIMITS_QOS_POLICY_ID        = 1003;
+  /// RTI DDS specific.
+  const QosPolicyId_t DATAWRITERRESOURCELIMITS_QOS_POLICY_ID        = 1004;
+  /// RTI DDS specific.
+  const QosPolicyId_t DATAREADERPROTOCOL_QOS_POLICY_ID              = 1005;
+  /// RTI DDS specific.
+  const QosPolicyId_t DATAWRITERPROTOCOL_QOS_POLICY_ID              = 1006;
+  /// RTI DDS specific.
+  const QosPolicyId_t DOMAINPARTICIPANTRESOURCELIMITS_QOS_POLICY_ID = 1007;
+  /// RTI DDS specific.
+  const QosPolicyId_t EVENT_QOS_POLICY_ID                           = 1008;
+  /// RTI DDS specific.
+  const QosPolicyId_t DATABASE_QOS_POLICY_ID                        = 1009;
+  /// RTI DDS specific.
+  const QosPolicyId_t RECEIVERPOOL_QOS_POLICY_ID                    = 1010;
+  /// RTI DDS specific.
+  const QosPolicyId_t DISCOVERYCONFIG_QOS_POLICY_ID                 = 1011;
+  /// RTI DDS specific.
+  const QosPolicyId_t EXCLUSIVEAREA_QOS_POLICY_ID                   = 1012;
+  /// RTI DDS specific.
+  const QosPolicyId_t USEROBJECT_QOS_POLICY_ID                      = 1013;
+  /// RTI DDS specific.
+  const QosPolicyId_t SYSTEMRESOURCELIMITS_QOS_POLICY_ID            = 1014;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTSELECTION_QOS_POLICY_ID              = 1015;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTUNICAST_QOS_POLICY_ID                = 1016;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTMULTICAST_QOS_POLICY_ID              = 1017;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTBUILTIN_QOS_POLICY_ID                = 1018;
+  /// RTI DDS specific.
+  const QosPolicyId_t TYPESUPPORT_QOS_POLICY_ID                     = 1019;
+  /// RTI DDS specific.
+  const QosPolicyId_t PROPERTY_QOS_POLICY_ID                        = 1020;
+  /// RTI DDS specific.
+  const QosPolicyId_t PUBLISHMODE_QOS_POLICY_ID                     = 1021;
+  /// RTI DDS specific.
+  const QosPolicyId_t ASYNCHRONOUSPUBLISHER_QOS_POLICY_ID           = 1022;
+  /// RTI DDS specific.
+  const QosPolicyId_t ENTITYNAME_QOS_POLICY_ID                      = 1023;
+  /// RTI DDS specific.
+  const QosPolicyId_t SERVICE_QOS_POLICY_ID                         = 1025;
+  /// RTI DDS specific.
+  const QosPolicyId_t BATCH_QOS_POLICY_ID                           = 1026;
+  /// RTI DDS specific.
+  const QosPolicyId_t PROFILE_QOS_POLICY_ID                         = 1027;
+  /// RTI DDS specific.
+  const QosPolicyId_t LOCATORFILTER_QOS_POLICY_ID                   = 1028;
+  /// RTI DDS specific.
+  const QosPolicyId_t MULTICHANNEL_QOS_POLICY_ID                    = 1029;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTENCAPSULATION_QOS_POLICY_ID          = 1030;
+  /// RTI DDS specific.
+  const QosPolicyId_t PUBLISHERPROTOCOL_QOS_POLICY_ID               = 1031;
+  /// RTI DDS specific.
+  const QosPolicyId_t SUBSCRIBERPROTOCOL_QOS_POLICY_ID              = 1032;
+  /// RTI DDS specific.
+  const QosPolicyId_t TOPICPROTOCOL_QOS_POLICY_ID                   = 1033;
+  /// RTI DDS specific.
+  const QosPolicyId_t DOMAINPARTICIPANTPROTOCOL_QOS_POLICY_ID       = 1034;
+  /// RTI DDS specific.
+  const QosPolicyId_t AVAILABILITY_QOS_POLICY_ID                    = 1035;
+  /// RTI DDS specific.
+  const QosPolicyId_t TRANSPORTMULTICASTMAPPING_QOS_POLICY_ID       = 1036;
+  /// RTI DDS specific.
+  const QosPolicyId_t LOGGING_QOS_POLICY_ID                         = 1037;
+
+  typedef sequence<octet> OctetSeq;
+
+  struct UserDataQosPolicy {
+      OctetSeq value;
+  };
+
+  struct TopicDataQosPolicy {
+      OctetSeq value;
+  };
+
+  struct GroupDataQosPolicy {
+      OctetSeq value;
+  };
+
+  struct TransportPriorityQosPolicy {
+      long value;
+  };
+
+  struct LifespanQosPolicy {
+      Duration_t duration;
+  };
+
+  enum DurabilityQosPolicyKind {
+      VOLATILE_DURABILITY_QOS,
+      TRANSIENT_LOCAL_DURABILITY_QOS,
+      TRANSIENT_DURABILITY_QOS,
+      PERSISTENT_DURABILITY_QOS
+  };
+  struct DurabilityQosPolicy {
+      DurabilityQosPolicyKind kind;
+  };
+
+  enum PresentationQosPolicyAccessScopeKind {
+      INSTANCE_PRESENTATION_QOS,
+      TOPIC_PRESENTATION_QOS,
+      GROUP_PRESENTATION_QOS,
+      /// RTI DDS specific
+      HIGHEST_OFFERED_PRESENTATION_QOS
+  };
+
+  struct PresentationQosPolicy {
+      PresentationQosPolicyAccessScopeKind access_scope;
+      boolean coherent_access;
+      boolean ordered_access;
+  };
+
+  struct DeadlineQosPolicy {
+      Duration_t period;
+  };
+
+  struct LatencyBudgetQosPolicy {
+      Duration_t duration;
+  };
+
+  enum OwnershipQosPolicyKind {
+      SHARED_OWNERSHIP_QOS,
+      EXCLUSIVE_OWNERSHIP_QOS
+  };
+
+  struct OwnershipQosPolicy {
+      OwnershipQosPolicyKind kind;
+  };
+
+  struct OwnershipStrengthQosPolicy {
+      long value;
+  };
+
+  enum LivelinessQosPolicyKind {
+      AUTOMATIC_LIVELINESS_QOS,
+      MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
+      MANUAL_BY_TOPIC_LIVELINESS_QOS
+  };
+
+  struct LivelinessQosPolicy {
+      LivelinessQosPolicyKind kind;
+      Duration_t lease_duration;
+  };
+
+  struct TimeBasedFilterQosPolicy {
+      Duration_t minimum_separation;
+  };
+
+  struct PartitionQosPolicy {
+      StringSeq name;
+  };
+
+  enum ReliabilityQosPolicyKind {
+      BEST_EFFORT_RELIABILITY_QOS,
+      RELIABLE_RELIABILITY_QOS
+  };
+
+  struct ReliabilityQosPolicy {
+      ReliabilityQosPolicyKind kind;
+      Duration_t max_blocking_time;
+  };
+
+  enum DestinationOrderQosPolicyKind {
+      BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
+      BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
+  };
+
+  /// RTI DDS specific
+  enum DestinationOrderQosPolicyScopeKind {
+      INSTANCE_SCOPE_DESTINATIONORDER_QOS,
+      TOPIC_SCOPE_DESTINATIONORDER_QOS
+  };
+
+  /// RTI DDS specific
+  enum DataWriterResourceLimitsInstanceReplacementKind {
+    UNREGISTERED_INSTANCE_REPLACEMENT,
+    ALIVE_INSTANCE_REPLACEMENT,
+    DISPOSED_INSTANCE_REPLACEMENT,
+    ALIVE_THEN_DISPOSED_INSTANCE_REPLACEMENT,
+    DISPOSED_THEN_ALIVE_INSTANCE_REPLACEMENT,
+    ALIVE_OR_DISPOSED_INSTANCE_REPLACEMENT
+  };
+
+  struct DestinationOrderQosPolicy {
+      DestinationOrderQosPolicyKind kind;
+      /// RTI DDS specific
+      DestinationOrderQosPolicyScopeKind scope;
+      /// RTI DDS specific
+      Duration_t source_timestamp_tolerance;
+  };
+
+  enum HistoryQosPolicyKind {
+      KEEP_LAST_HISTORY_QOS,
+      KEEP_ALL_HISTORY_QOS
+  };
+
+  /// RTI DDS specific
+  enum RefilterQosPolicyKind {
+      NONE_REFILTER_QOS,
+      ALL_REFILTER_QOS,
+      ON_DEMAND_REFILTER_QOS
+  };
+
+  struct HistoryQosPolicy {
+      HistoryQosPolicyKind kind;
+      long depth;
+      /// RTI DDS specific
+      RefilterQosPolicyKind refilter;
+  };
+
+  struct ResourceLimitsQosPolicy {
+      long max_samples;
+      long max_instances;
+      long max_samples_per_instance;
+      /// RTI DDS specific
+      long initial_samples;
+      /// RTI DDS specific
+      long initial_instances;
+      /// RTI DDS specific
+      long instance_hash_buckets;
+  };
+
+  struct EntityFactoryQosPolicy {
+      boolean autoenable_created_entities;
+  };
+
+  struct WriterDataLifecycleQosPolicy {
+      boolean autodispose_unregistered_instances;
+  };
+
+  /// RTI DDS specific
+  struct DataReaderResourceLimitsQosPolicy {
+    long max_remote_writers;
+    long max_remote_writers_per_instance;
+    long max_samples_per_remote_writer;
+    long max_infos;
+    long initial_remote_writers;
+    long initial_remote_writers_per_instance;
+    long initial_infos;
+    long initial_outstanding_reads;
+    long max_outstanding_reads;
+    long max_samples_per_read;
+    boolean disable_fragmentation_support;
+    long max_fragmented_samples;
+    long initial_fragmented_samples;
+    long max_fragmented_samples_per_remote_writer;
+    long max_fragments_per_sample;
+    boolean dynamically_allocate_fragmented_samples;
+    long max_total_instances;
+    long max_remote_virtual_writers_per_instance;
+    long initial_remote_virtual_writers_per_instance;
+    long max_query_condition_filters;
+  };
+
+  /// RTI DDS specific
+  struct DataWriterResourceLimitsQosPolicy {
+    long initial_concurrent_blocking_threads;
+    long max_concurrent_blocking_threads;
+    long max_remote_reader_filters;
+    long initial_batches;
+    long max_batches;
+    long cookie_max_length;
+    DataWriterResourceLimitsInstanceReplacementKind instance_replacement;
+    boolean replace_empty_instances;
+    boolean autoregister_instances;
+  };
+
+  struct ReaderDataLifecycleQosPolicy {
+      Duration_t autopurge_nowriter_samples_delay;
+      Duration_t autopurge_disposed_samples_delay;
+  };
+
+  struct DurabilityServiceQosPolicy {
+      Duration_t              service_cleanup_delay;
+      HistoryQosPolicyKind    history_kind;
+      long                    history_depth;
+      long                    max_samples;
+      long                    max_instances;
+      long                    max_samples_per_instance;
+  };
+
+  struct DomainParticipantFactoryQos {
+      EntityFactoryQosPolicy entity_factory;
+  };
+
+  struct DomainParticipantQos {
+      UserDataQosPolicy  user_data;
+      EntityFactoryQosPolicy entity_factory;
+  };
+
+  struct TopicQos {
+      TopicDataQosPolicy                   topic_data;
+      DurabilityQosPolicy                  durability;
+      DurabilityServiceQosPolicy           durability_service;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      DestinationOrderQosPolicy            destination_order;
+      HistoryQosPolicy                     history;
+      ResourceLimitsQosPolicy              resource_limits;
+      TransportPriorityQosPolicy           transport_priority;
+      LifespanQosPolicy                    lifespan;
+
+      OwnershipQosPolicy                   ownership;
+  };
+
+  struct DataWriterQos {
+      DurabilityQosPolicy                  durability;
+      DurabilityServiceQosPolicy           durability_service;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      DestinationOrderQosPolicy            destination_order;
+      HistoryQosPolicy                     history;
+      ResourceLimitsQosPolicy              resource_limits;
+      TransportPriorityQosPolicy           transport_priority;
+      LifespanQosPolicy                    lifespan;
+
+      UserDataQosPolicy                    user_data;
+      OwnershipQosPolicy                   ownership;
+      OwnershipStrengthQosPolicy           ownership_strength;
+      WriterDataLifecycleQosPolicy         writer_data_lifecycle;
+
+      /// RTI DDS specific
+      DataWriterResourceLimitsQosPolicy    writer_resource_limits;
+  };
+
+  struct PublisherQos {
+      PresentationQosPolicy                presentation;
+      PartitionQosPolicy                   partition;
+      GroupDataQosPolicy                   group_data;
+      EntityFactoryQosPolicy               entity_factory;
+  };
+
+  struct DataReaderQos {
+      DurabilityQosPolicy                  durability;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      DestinationOrderQosPolicy            destination_order;
+      HistoryQosPolicy                     history;
+      ResourceLimitsQosPolicy              resource_limits;
+
+      UserDataQosPolicy                    user_data;
+      OwnershipQosPolicy                   ownership;
+      TimeBasedFilterQosPolicy             time_based_filter;
+      ReaderDataLifecycleQosPolicy         reader_data_lifecycle;
+
+      /// RTI DDS specific
+      DataReaderResourceLimitsQosPolicy    reader_resource_limits;
+
+      /// RTI DDS specific
+      TypeConsistencyEnforcementQosPolicy  type_consistency;
+  };
+
+  struct SubscriberQos {
+      PresentationQosPolicy                presentation;
+      PartitionQosPolicy                   partition;
+      GroupDataQosPolicy                   group_data;
+      EntityFactoryQosPolicy               entity_factory;
+  };
+
+  // ----------------------------------------------------------------------
+
+  struct ParticipantBuiltinTopicData {
+      BuiltinTopicKey_t                    key;
+      UserDataQosPolicy                    user_data;
+  };
+
+  struct TopicBuiltinTopicData {
+      BuiltinTopicKey_t                    key;
+      string                               name;
+      string                               type_name;
+      DurabilityQosPolicy                  durability;
+      DurabilityServiceQosPolicy           durability_service;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      TransportPriorityQosPolicy           transport_priority;
+      LifespanQosPolicy                    lifespan;
+      DestinationOrderQosPolicy            destination_order;
+      HistoryQosPolicy                     history;
+      ResourceLimitsQosPolicy              resource_limits;
+      OwnershipQosPolicy                   ownership;
+      TopicDataQosPolicy                   topic_data;
+  };
+
+  struct PublicationBuiltinTopicData {
+      BuiltinTopicKey_t                    key;
+      BuiltinTopicKey_t                    participant_key;
+      string                               topic_name;
+      string                               type_name;
+
+      DurabilityQosPolicy                  durability;
+      DurabilityServiceQosPolicy           durability_service;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      LifespanQosPolicy                    lifespan;
+      UserDataQosPolicy                    user_data;
+      OwnershipQosPolicy                   ownership;
+      OwnershipStrengthQosPolicy           ownership_strength;
+      DestinationOrderQosPolicy            destination_order;
+
+      PresentationQosPolicy                presentation;
+      PartitionQosPolicy                   partition;
+      TopicDataQosPolicy                   topic_data;
+      GroupDataQosPolicy                   group_data;
+  };
+
+  struct SubscriptionBuiltinTopicData {
+      BuiltinTopicKey_t                    key;
+      BuiltinTopicKey_t                    participant_key;
+      string                               topic_name;
+      string                               type_name;
+
+      DurabilityQosPolicy                  durability;
+      DeadlineQosPolicy                    deadline;
+      LatencyBudgetQosPolicy               latency_budget;
+      LivelinessQosPolicy                  liveliness;
+      ReliabilityQosPolicy                 reliability;
+      OwnershipQosPolicy                   ownership;
+      DestinationOrderQosPolicy            destination_order;
+      UserDataQosPolicy                    user_data;
+      TimeBasedFilterQosPolicy             time_based_filter;
+
+      PresentationQosPolicy                presentation;
+      PartitionQosPolicy                   partition;
+      TopicDataQosPolicy                   topic_data;
+      GroupDataQosPolicy                   group_data;
+  };
+
+  // ----------------------------------------------------------------------
+
+  local interface Entity {
+  //  ReturnCode_t set_qos(
+  //      in EntityQos qos);
+  //  ReturnCode_t get_qos(
+  //      inout EntityQos qos);
+  //  ReturnCode_t set_listener(
+  //      in Listener l,
+  //      in StatusMask mask);
+  //  Listener get_listener();
+
+      ReturnCode_t enable();
+
+      StatusCondition get_statuscondition();
+
+      StatusMask get_status_changes();
+
+      InstanceHandle_t get_instance_handle();
+  };
+
+  local interface DomainParticipant : Entity {
+      // Factory interfaces
+      Publisher create_publisher(
+          in PublisherQos qos,
+          in PublisherListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      Publisher create_publisher_with_profile(
+          in string qos_profile,
+          in PublisherListener a_listener,
+          in StatusMask mask);
+      ReturnCode_t delete_publisher(
+          in Publisher p);
+
+      Subscriber create_subscriber(
+          in SubscriberQos qos,
+          in SubscriberListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      Subscriber create_subscriber_with_profile(
+          in string qos_profile,
+          in SubscriberListener a_listener,
+          in StatusMask mask);
+      ReturnCode_t delete_subscriber(
+          in Subscriber s);
+      Subscriber get_builtin_subscriber();
+
+      Topic create_topic(
+          in string topic_name,
+          in string type_name,
+          in TopicQos qos,
+          in TopicListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      Topic create_topic_with_profile(
+          in string topic_name,
+          in string type_name,
+          in string qos_profile,
+          in TopicListener a_listener,
+          in StatusMask mask);
+
+      ReturnCode_t delete_topic(
+          in Topic a_topic);
+
+      Topic find_topic(
+          in string topic_name,
+          in Duration_t timeout);
+      TopicDescription lookup_topicdescription(
+          in string name);
+
+      ContentFilteredTopic create_contentfilteredtopic(
+          in string name,
+          in Topic related_topic,
+          in string filter_expression,
+          in StringSeq expression_parameters);
+
+      ReturnCode_t delete_contentfilteredtopic(
+          in ContentFilteredTopic a_contentfilteredtopic);
+
+      MultiTopic create_multitopic(
+          in string name,
+          in string type_name,
+          in string subscription_expression,
+          in StringSeq expression_parameters);
+
+      ReturnCode_t delete_multitopic(
+          in MultiTopic a_multitopic);
+
+      ReturnCode_t delete_contained_entities();
+
+      ReturnCode_t set_qos(
+          in DomainParticipantQos qos);
+      ReturnCode_t get_qos(
+          inout DomainParticipantQos qos);
+
+      ReturnCode_t set_listener(
+          in DomainParticipantListener a_listener,
+          in StatusMask mask);
+      DomainParticipantListener get_listener();
+
+      ReturnCode_t ignore_participant(
+          in InstanceHandle_t handle);
+      ReturnCode_t ignore_topic(
+          in InstanceHandle_t handle);
+      ReturnCode_t ignore_publication(
+          in InstanceHandle_t handle);
+      ReturnCode_t ignore_subscription(
+          in InstanceHandle_t handle);
+
+      DomainId_t get_domain_id();
+      ReturnCode_t assert_liveliness();
+
+      ReturnCode_t set_default_publisher_qos(
+          in PublisherQos qos);
+      ReturnCode_t get_default_publisher_qos(
+          inout PublisherQos qos);
+
+      ReturnCode_t set_default_subscriber_qos(
+          in SubscriberQos qos);
+      ReturnCode_t get_default_subscriber_qos(
+          inout SubscriberQos qos);
+
+      ReturnCode_t set_default_topic_qos(
+          in TopicQos qos);
+      ReturnCode_t get_default_topic_qos(
+          inout TopicQos qos);
+
+      ReturnCode_t get_discovered_participants(
+          inout InstanceHandleSeq participant_handles);
+      ReturnCode_t get_discovered_participant_data(
+          inout ParticipantBuiltinTopicData participant_data,
+          in InstanceHandle_t participant_handle);
+
+      ReturnCode_t get_discovered_topics(
+          inout InstanceHandleSeq topic_handles);
+      ReturnCode_t get_discovered_topic_data(
+          inout TopicBuiltinTopicData topic_data,
+          in InstanceHandle_t topic_handle);
+
+      boolean contains_entity(
+          in InstanceHandle_t a_handle);
+
+      ReturnCode_t get_current_time(
+          inout Time_t current_time);
+  };
+
+  local interface DomainParticipantFactory {
+      DomainParticipant create_participant(
+          in DomainId_t domain_id,
+          in DomainParticipantQos qos,
+          in DomainParticipantListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      DomainParticipant create_participant_with_profile(
+          in DomainId_t domain_id,
+          in string qos_profile,
+          in DomainParticipantListener a_listener,
+          in StatusMask mask);
+      ReturnCode_t delete_participant(
+          in DomainParticipant a_participant);
+
+      DomainParticipant lookup_participant(
+          in DomainId_t domain_id);
+
+      ReturnCode_t set_default_participant_qos(
+          in DomainParticipantQos qos);
+      /// RTI DDS specific
+      ReturnCode_t set_default_participant_qos_with_profile(
+          in string qos_profile);
+      ReturnCode_t get_default_participant_qos(
+          inout DomainParticipantQos qos);
+
+      ReturnCode_t set_qos(
+          in DomainParticipantFactoryQos qos);
+      ReturnCode_t get_qos(
+          inout DomainParticipantFactoryQos qos);
+
+      // Extension to nicely close the domain participant factory
+      ReturnCode_t finalize_instance ();
+  };
+
+  local interface TypeSupport {
+        ReturnCode_t register_type(
+            in DomainParticipant domain,
+            in string type_name);
+        ReturnCode_t unregister_type(
+            in DomainParticipant domain,
+            in string type_name);
         string get_type_name();
-        string get_name();
+  };
 
-        DomainParticipant get_participant();
-    };
+  // ----------------------------------------------------------------------
+  local interface TopicDescription {
+      string get_type_name();
+      string get_name();
 
-    local interface Topic : Entity, TopicDescription {
-        ReturnCode_t set_qos(
-            in TopicQos qos);
-        ReturnCode_t get_qos(
-            inout TopicQos qos);
-        ReturnCode_t set_listener(
-            in TopicListener a_listener,
-            in StatusMask mask);
-        TopicListener get_listener();
-        // Access the status
-        ReturnCode_t get_inconsistent_topic_status(
-            inout InconsistentTopicStatus a_status);
-    };
+      DomainParticipant get_participant();
+  };
 
-    local interface ContentFilteredTopic : TopicDescription {
-        string get_filter_expression();
-        ReturnCode_t get_expression_parameters(
-            inout StringSeq expression_parameters);
-        ReturnCode_t set_expression_parameters(
-            in StringSeq expression_parameters);
-        Topic get_related_topic();
-    };
+  local interface Topic : Entity, TopicDescription {
+      ReturnCode_t set_qos(
+          in TopicQos qos);
+      ReturnCode_t get_qos(
+          inout TopicQos qos);
+      ReturnCode_t set_listener(
+          in TopicListener a_listener,
+          in StatusMask mask);
+      TopicListener get_listener();
+      // Access the status
+      ReturnCode_t get_inconsistent_topic_status(
+          inout InconsistentTopicStatus a_status);
+  };
 
-    local interface MultiTopic : TopicDescription {
-        string get_subscription_expression();
-        ReturnCode_t get_expression_parameters(
-            inout StringSeq expression_parameters);
-        ReturnCode_t set_expression_parameters(
-            in StringSeq expression_parameters);
-    };
+  local interface ContentFilteredTopic : TopicDescription {
+      string get_filter_expression();
+      ReturnCode_t get_expression_parameters(
+          inout StringSeq expression_parameters);
+      ReturnCode_t set_expression_parameters(
+          in StringSeq expression_parameters);
+      Topic get_related_topic();
+  };
 
-    local interface Publisher : Entity {
-        DataWriter create_datawriter(
-            in Topic a_topic,
-            in DataWriterQos qos,
-            in DataWriterListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        DataWriter create_datawriter_with_profile(
-            in Topic a_topic,
-            in string qos_profile,
-            in DataWriterListener a_listener,
-            in StatusMask mask);
-        ReturnCode_t delete_datawriter(
-            in DataWriter a_datawriter);
-        DataWriter lookup_datawriter(
-            in string topic_name);
+  local interface MultiTopic : TopicDescription {
+      string get_subscription_expression();
+      ReturnCode_t get_expression_parameters(
+          inout StringSeq expression_parameters);
+      ReturnCode_t set_expression_parameters(
+          in StringSeq expression_parameters);
+  };
 
-        ReturnCode_t delete_contained_entities();
+  local interface Publisher : Entity {
+      DataWriter create_datawriter(
+          in Topic a_topic,
+          in DataWriterQos qos,
+          in DataWriterListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      DataWriter create_datawriter_with_profile(
+          in Topic a_topic,
+          in string qos_profile,
+          in DataWriterListener a_listener,
+          in StatusMask mask);
+      ReturnCode_t delete_datawriter(
+          in DataWriter a_datawriter);
+      DataWriter lookup_datawriter(
+          in string topic_name);
 
-        ReturnCode_t set_qos(
-            in PublisherQos qos);
-        ReturnCode_t get_qos(
-            inout PublisherQos qos);
+      ReturnCode_t delete_contained_entities();
 
-        ReturnCode_t set_listener(
-            in PublisherListener a_listener,
-            in StatusMask mask);
-        PublisherListener get_listener();
+      ReturnCode_t set_qos(
+          in PublisherQos qos);
+      ReturnCode_t get_qos(
+          inout PublisherQos qos);
 
-        ReturnCode_t suspend_publications();
-        ReturnCode_t resume_publications();
+      ReturnCode_t set_listener(
+          in PublisherListener a_listener,
+          in StatusMask mask);
+      PublisherListener get_listener();
 
-        ReturnCode_t begin_coherent_changes();
-        ReturnCode_t end_coherent_changes();
+      ReturnCode_t suspend_publications();
+      ReturnCode_t resume_publications();
 
-        ReturnCode_t wait_for_acknowledgments(
-            in Duration_t max_wait);
+      ReturnCode_t begin_coherent_changes();
+      ReturnCode_t end_coherent_changes();
 
-        DomainParticipant get_participant();
+      ReturnCode_t wait_for_acknowledgments(
+          in Duration_t max_wait);
 
-        ReturnCode_t set_default_datawriter_qos(
-            in DataWriterQos qos);
-        ReturnCode_t get_default_datawriter_qos(
-            inout DataWriterQos qos);
+      DomainParticipant get_participant();
 
-        ReturnCode_t copy_from_topic_qos(
-            inout DataWriterQos a_datawriter_qos,
-            in TopicQos a_topic_qos);
-    };
+      ReturnCode_t set_default_datawriter_qos(
+          in DataWriterQos qos);
+      ReturnCode_t get_default_datawriter_qos(
+          inout DataWriterQos qos);
 
-    // ----------------------------------------------------------------------
-    local interface Subscriber : Entity {
-        DataReader create_datareader(
-            in TopicDescription a_topic,
-            in DataReaderQos qos,
-            in DataReaderListener a_listener,
-            in StatusMask mask);
-        /// RTI DDS specific
-        DataReader create_datareader_with_profile(
-            in TopicDescription a_topic,
-            in string qos_profile,
-            in DataReaderListener a_listener,
-            in StatusMask mask);
-        ReturnCode_t delete_datareader(
-            in DataReader a_datareader);
-        ReturnCode_t delete_contained_entities();
-        DataReader lookup_datareader(
-            in string topic_name);
-        ReturnCode_t get_datareaders(
-            inout DataReaderSeq readers,
-            in SampleStateMask sample_states,
-            in ViewStateMask view_states,
-            in InstanceStateMask instance_states);
-        ReturnCode_t notify_datareaders();
+      ReturnCode_t copy_from_topic_qos(
+          inout DataWriterQos a_datawriter_qos,
+          in TopicQos a_topic_qos);
+  };
 
-        ReturnCode_t set_qos(
-            in SubscriberQos qos);
-        ReturnCode_t get_qos(
-            inout SubscriberQos qos);
+  // ----------------------------------------------------------------------
+  local interface Subscriber : Entity {
+      DataReader create_datareader(
+          in TopicDescription a_topic,
+          in DataReaderQos qos,
+          in DataReaderListener a_listener,
+          in StatusMask mask);
+      /// RTI DDS specific
+      DataReader create_datareader_with_profile(
+          in TopicDescription a_topic,
+          in string qos_profile,
+          in DataReaderListener a_listener,
+          in StatusMask mask);
+      ReturnCode_t delete_datareader(
+          in DataReader a_datareader);
+      ReturnCode_t delete_contained_entities();
+      DataReader lookup_datareader(
+          in string topic_name);
+      ReturnCode_t get_datareaders(
+          inout DataReaderSeq readers,
+          in SampleStateMask sample_states,
+          in ViewStateMask view_states,
+          in InstanceStateMask instance_states);
+      ReturnCode_t notify_datareaders();
 
-        ReturnCode_t set_listener(
-            in SubscriberListener a_listener,
-            in StatusMask mask);
-        SubscriberListener get_listener();
+      ReturnCode_t set_qos(
+          in SubscriberQos qos);
+      ReturnCode_t get_qos(
+          inout SubscriberQos qos);
 
-        ReturnCode_t begin_access();
-        ReturnCode_t end_access();
+      ReturnCode_t set_listener(
+          in SubscriberListener a_listener,
+          in StatusMask mask);
+      SubscriberListener get_listener();
 
-        DomainParticipant get_participant();
+      ReturnCode_t begin_access();
+      ReturnCode_t end_access();
 
-        ReturnCode_t set_default_datareader_qos(
-            in DataReaderQos qos);
-        ReturnCode_t get_default_datareader_qos(
-            inout DataReaderQos qos);
+      DomainParticipant get_participant();
 
-        ReturnCode_t copy_from_topic_qos(
-            inout DataReaderQos a_datareader_qos,
-            in TopicQos a_topic_qos);
-    };
+      ReturnCode_t set_default_datareader_qos(
+          in DataReaderQos qos);
+      ReturnCode_t get_default_datareader_qos(
+          inout DataReaderQos qos);
 
-    // ----------------------------------------------------------------------
-    struct SampleInfo {
-        SampleStateKind      sample_state;
-        ViewStateKind        view_state;
-        InstanceStateKind    instance_state;
-        Time_t               source_timestamp;
-        InstanceHandle_t     instance_handle;
-        InstanceHandle_t     publication_handle;
-        long                 disposed_generation_count;
-        long                 no_writers_generation_count;
-        long                 sample_rank;
-        long                 generation_rank;
-        long                 absolute_generation_rank;
-        boolean              valid_data;
-    };
+      ReturnCode_t copy_from_topic_qos(
+          inout DataReaderQos a_datareader_qos,
+          in TopicQos a_topic_qos);
+  };
 
-    typedef sequence<SampleInfo> SampleInfoSeq;
+  // ----------------------------------------------------------------------
+  struct SampleInfo {
+      SampleStateKind      sample_state;
+      ViewStateKind        view_state;
+      InstanceStateKind    instance_state;
+      Time_t               source_timestamp;
+      InstanceHandle_t     instance_handle;
+      InstanceHandle_t     publication_handle;
+      long                 disposed_generation_count;
+      long                 no_writers_generation_count;
+      long                 sample_rank;
+      long                 generation_rank;
+      long                 absolute_generation_rank;
+      boolean              valid_data;
+  };
+
+  typedef sequence<SampleInfo> SampleInfoSeq;
 };
 
 #endif /* NDDS_DCPS_ALL_IDL_ */

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_instance_handle.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_instance_handle.idl
@@ -11,13 +11,12 @@
 module DDS {
   typedef octet octet_value[16];
 
-  struct NativeInstanceHandle_t
+  struct InstanceHandle_t
   {
     octet_value value;
     unsigned long length;
     boolean isValid;
   };
-  typedef NativeInstanceHandle_t InstanceHandle_t;
 };
 
 #endif /* DDS_DCPS_INSTANCE_HANDLE_IDL_ */

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
@@ -2,8 +2,7 @@
  * @file    ndds_dcps_types.idl
  * @author  Marcel Smit
  *
- * @brief   Placeholder for anytypecode.
- *          RTI NDDS compliant IDL code.
+ * @brief   All DDS IDL types for which we need to generate AnyTypecode support
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
  */
@@ -12,11 +11,12 @@
 #define NDDS_DCPS_TYPES_IDL_
 
 module DDS {
+  // For DomainId_t AnyTypecode support has to be generated because it is in the
+  // DDS4CCM IDL as attribute
   typedef long DomainId_t;
 
-  // @todo, move this to its own file so that we can put the converter into the core????
-  typedef unsigned long long_4[4];
-
+  // For StringSeq AnyTypecode support has to be generated because it is in the
+  // DDS4CCM IDL as attribute
   typedef sequence<string> StringSeq;
 };
 

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
@@ -12,13 +12,12 @@
 #define NDDS_DCPS_TYPES_IDL_
 
 #define HANDLE_TYPE_NATIVE      long
-#define BUILTIN_TOPIC_KEY_TYPE_NATIVE unsigned long
 
 module DDS {
   typedef long DomainId_t;
 
   // @todo, move this to its own file so that we can put the converter into the core????
-  typedef BUILTIN_TOPIC_KEY_TYPE_NATIVE long_4[4];
+  typedef unsigned long long_4[4];
 
   typedef sequence<string> StringSeq;
 };

--- a/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
+++ b/ddsx11/vendors/ndds/idl/ndds_dcps_types.idl
@@ -11,8 +11,6 @@
 #ifndef NDDS_DCPS_TYPES_IDL_
 #define NDDS_DCPS_TYPES_IDL_
 
-#define HANDLE_TYPE_NATIVE      long
-
 module DDS {
   typedef long DomainId_t;
 


### PR DESCRIPTION
* Extended MPC files of the DDSX11 unit tests to support multiple vendors
* Cleanup of the core DDSX11 IDL
* Moved some IDL types to other files and document why some are separate
* Suppress generation of S.* files
* Removed a few defines in the core IDL which are not used