### PR TITLE
Fixed regex when the instance handle is just a long

### DIFF
--- a/ddsx11/tests/log_formatters/log_check.pl
+++ b/ddsx11/tests/log_formatters/log_check.pl
@@ -35,7 +35,7 @@ sub check_instance_handle
     {
       return 1;
     }
-    if ($line =~ /\Q\{1234567\}\E/ )
+    if ($line =~ /\Q{1234567}\E/ )
     {
       return 1;
     }


### PR DESCRIPTION
    * ddsx11/tests/log_formatters/log_check.pl: