### PR TITLE
Extend unkeyed writer test with a check that we receive each unique s…

### DIFF
--- a/connectors/dds4ccm/tests/union/toplevel/sender/top_union_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/union/toplevel/sender/top_union_sender_exec.cpp
@@ -250,7 +250,7 @@ namespace Uni_Sender_Impl
   {
     try
     {
-      IDL::traits < Uni::TopUnionConnector::Writer>::ref_type writer =
+      IDL::traits <Uni::TopUnionConnector::Writer>::ref_type writer =
         this->context_->get_connection_info_write_data ();
 
       switch (this->last_assignment_)

--- a/connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.cpp
@@ -32,7 +32,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
   info_out_data_listener_exec_i::info_out_data_listener_exec_i (
     IDL::traits<UnkeyedWriterTest::CCM_Receiver_Context>::ref_type context,
     uint16_t iterations,
-    std::atomic_ulong &samples_received)
+    std::atomic<uint32_t> &samples_received)
     : context_ (std::move (context))
     , iterations_ (iterations)
     , samples_received_ (samples_received)
@@ -67,6 +67,12 @@ namespace UnkeyedWriterTest_Receiver_Impl
   {
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : UnkeyedWriterTest_Receiver_Impl::info_out_data_listener_exec_i::on_one_data[_datum_info]
     X11_UNUSED_ARG(info);
+    if (datum.sample_index () != this->samples_received_)
+    {
+      DDS4CCM_TEST_ERROR << "ERROR: received sample <" << datum.sample_index ()
+        << "> but we expected sample <"
+        << this->samples_received_ << ">" << std::endl;
+    }
     ++this->samples_received_;
     DDS4CCM_TEST_DEBUG << "info_out_data_listener_exec_i::on_one_data received writer "
       << "info : " << datum << std::endl;
@@ -74,7 +80,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
     {
       DDS4CCM_TEST_ERROR << "ERROR: received iteration greater than expected : "
         << "expected <" << this->iterations_ << "> - received <"
-        << datum.iteration () << ">." << std::endl;
+        << datum.iteration () << ">" << std::endl;
     }
     if (datum.iteration () == 0)
     {
@@ -222,14 +228,14 @@ namespace UnkeyedWriterTest_Receiver_Impl
         DDS4CCM_TEST_ERROR << "ERROR: Receiver_exec_i::ccm_passivate - "
           << "Did not receive the expected number of samples: "
           << "expected <" << expected << "> - received <"
-          << this->samples_received_ << ">." << std::endl;
+          << this->samples_received_ << ">" << std::endl;
       }
       else
       {
         DDS4CCM_TEST_DEBUG << "Receiver_exec_i::ccm_passivate - "
                   << "Did receive the expected number of samples: "
                   << "expected <" << expected << "> - received <"
-                  << this->samples_received_ << ">." << std::endl;
+                  << this->samples_received_ << ">" << std::endl;
 
       }
     }
@@ -240,7 +246,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
         DDS4CCM_TEST_ERROR << "ERROR: Receiver_exec_i::ccm_passivate - "
           << "Did not receive the expected number of samples: "
           << "expected at least ten percent of <" << expected << "> - received <"
-          << this->samples_received_ << ">." << std::endl;
+          << this->samples_received_ << ">" << std::endl;
       }
     }
     //@@{__RIDL_REGEN_MARKER__} - END : UnkeyedWriterTest_Receiver_Impl::Receiver_exec_i[ccm_passivate]

--- a/connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.h
+++ b/connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.h
@@ -49,7 +49,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
     info_out_data_listener_exec_i (
       IDL::traits<UnkeyedWriterTest::CCM_Receiver_Context>::ref_type context,
       uint16_t iterations,
-      std::atomic_ulong &samples_received);
+      std::atomic<uint32_t> &samples_received);
     //@@{__RIDL_REGEN_MARKER__} - END : UnkeyedWriterTest_Receiver_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
@@ -84,7 +84,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
     //@{
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : UnkeyedWriterTest_Receiver_Impl::info_out_data_listener_exec_i[user_members]
     uint16_t iterations_ {};
-    std::atomic_ulong &samples_received_;
+    std::atomic<uint32_t> &samples_received_;
     //@@{__RIDL_REGEN_MARKER__} - END : UnkeyedWriterTest_Receiver_Impl::info_out_data_listener_exec_i[user_members]
     //@}
 
@@ -243,7 +243,7 @@ namespace UnkeyedWriterTest_Receiver_Impl
     /** @name User defined members. */
     //@{
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : UnkeyedWriterTest_Receiver_Impl::Receiver_exec_i[user_members]
-    std::atomic_ulong samples_received_ {};
+    std::atomic<uint32_t> samples_received_ {};
     //@@{__RIDL_REGEN_MARKER__} - END : UnkeyedWriterTest_Receiver_Impl::Receiver_exec_i[user_members]
     //@}
 

--- a/connectors/dds4ccm/tests/unkeyed_writer/components/sender/unkeyed_writer_sender_exec.h
+++ b/connectors/dds4ccm/tests/unkeyed_writer/components/sender/unkeyed_writer_sender_exec.h
@@ -232,8 +232,8 @@ namespace UnkeyedWriterTest_Sender_Impl
     IDL::traits<CCM_TT::TT_Timer>::ref_type tm_activate_;
     IDL::traits<CCM_TT::TT_Scheduler>::ref_type tt_s;
     bool already_publishing_ {};
-
-
+    /// Each sample we send receives an unique index which we will check at the receiver side
+    uint32_t sample_index_ {};
 
     std::mutex mutex_ {};
     typedef std::map<std::string, UnkeyedWriterTest::UnkeyedWriterMessage> Writer_Table;

--- a/connectors/dds4ccm/tests/unkeyed_writer/data/unkeyed_writer.idl
+++ b/connectors/dds4ccm/tests/unkeyed_writer/data/unkeyed_writer.idl
@@ -15,8 +15,12 @@ module UnkeyedWriterTest
 {
   struct UnkeyedWriterMessage {
     string key;
-    long iteration;
+    unsigned long iteration;
     ::OctetSeq data;
+    /// Unique index for each sample we write so that
+    /// the receiver can check that we don't get duplicate
+    /// samples
+    unsigned long sample_index;
   }; //@TopLevel()
 };
 


### PR DESCRIPTION
…ample send, it could happen we got some samples multiple times and missed others

    * connectors/dds4ccm/tests/union/toplevel/sender/top_union_sender_exec.cpp:
    * connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.cpp:
    * connectors/dds4ccm/tests/unkeyed_writer/components/receiver/unkeyed_writer_receiver_exec.h:
    * connectors/dds4ccm/tests/unkeyed_writer/components/sender/unkeyed_writer_sender_exec.cpp:
    * connectors/dds4ccm/tests/unkeyed_writer/components/sender/unkeyed_writer_sender_exec.h:
    * connectors/dds4ccm/tests/unkeyed_writer/data/unkeyed_writer.idl: