### PR TITLE
Use the native DDS entity pointer as key for our internal maps

### DIFF
--- a/ddsx11/dds/dds_data_writer_listener.cpp
+++ b/ddsx11/dds/dds_data_writer_listener.cpp
@@ -62,7 +62,6 @@ namespace DDSX11
     }
   }
 
-
   void
   DDS_DataWriterListener_proxy::on_offered_incompatible_qos (
     DDS_Native::DDS::DataWriter *the_writer,

--- a/ddsx11/dds/dds_domain_participant.cpp
+++ b/ddsx11/dds/dds_domain_participant.cpp
@@ -97,7 +97,7 @@ namespace DDSX11
 
     if (publisher)
       {
-        if (DDS_ProxyEntityManager::register_publisher_proxy (publisher))
+        if (DDS_ProxyEntityManager::register_publisher_proxy (publisher, native_pub))
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_publisher - "
               << "Successfully created and registered a publisher.");
@@ -169,7 +169,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_publisher_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_publisher_proxy (native_pub, handle))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_publisher - "
               << "Error: Can't unregister publisher proxy for <" <<handle << ">");
@@ -249,7 +249,7 @@ namespace DDSX11
     if (subscriber)
       {
         // Register the fresh created proxy in the proxy entity manager
-        if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber))
+        if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber, native_sub))
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_subscriber - "
               << "Successfully created and registered a subscriber.");
@@ -322,7 +322,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_subscriber_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_subscriber_proxy (native_sub, handle))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_subscriber - "
               << "Error: Can't unregister subscriber proxy for <" << handle << ">");
@@ -448,7 +448,7 @@ namespace DDSX11
 
     if (topic_reference)
       {
-        if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference))
+        if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference, dds_tp))
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipant_proxy::create_topic - "
               << "Successfully created and registered a Topic.");
@@ -522,7 +522,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_topic_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_topic_proxy (top, handle))
           {
             // The topic proxy is still used, so don't destruct the listener yet
             listener_guard.release ();
@@ -569,7 +569,7 @@ namespace DDSX11
       {
         // We have an existing topic proxy so we register it again to increment
         // its refcount with 1
-        if (!DDS_ProxyEntityManager::register_topic_proxy (topic))
+        if (!DDS_ProxyEntityManager::register_topic_proxy (topic, native_topic))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::find_topic - "
               << "Error: Error registering topic proxy for <" << impl_name << "> again <"

--- a/ddsx11/dds/dds_domain_participant_factory.cpp
+++ b/ddsx11/dds/dds_domain_participant_factory.cpp
@@ -92,7 +92,7 @@ namespace DDSX11
 
     if (domain_participant)
       {
-        if (DDS_ProxyEntityManager::register_dp_proxy (domain_participant))
+        if (DDS_ProxyEntityManager::register_dp_proxy (domain_participant, dds_dp))
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_DomainParticipantFactory_proxy::create_participant - "
               << "Successfully created and registered a DomainParticipant for domain <"
@@ -168,7 +168,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_dp_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_dp_proxy (part, handle))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_participant - "
               << "Error: Can't unregister domainparticpant proxy for <" << handle << ">");

--- a/ddsx11/dds/dds_proxy_entity_manager.cpp
+++ b/ddsx11/dds/dds_proxy_entity_manager.cpp
@@ -44,12 +44,12 @@ namespace DDSX11
     if (!ret.second)
     {
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::register_proxy - "
-        "Registering proxy <" << proxy->get_instance_handle () << "> failed");
+        "Registering proxy <" << proxy->get_instance_handle () << ":" << native_entity << "> failed");
       return false;
     }
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << "> succeeded");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << "> succeeded");
 
     return true;
   }
@@ -79,7 +79,7 @@ namespace DDSX11
           native_entity->get_instance_handle ());
 
       DDSX11_IMPL_LOG_INFO ("DDS_ProxyEntityManager::get_proxy - "
-        << "Could not find a proxy with handle <" << handle
+        << "Could not find a proxy with handle <" << handle << ":" << native_entity
         << ">");
     }
     return {};
@@ -95,14 +95,14 @@ namespace DDSX11
     if (lst.erase (native_entity) > 0)
     {
       DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_proxy - "
-        << "Removed proxy with handle <" << instance_handle
+        << "Removed proxy with handle <" << instance_handle << ":" << native_entity
         << "> from the list");
       return true;
     }
     else
     {
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::unregister_proxy - "
-        << "Could not find a proxy with handle <" << instance_handle
+        << "Could not find a proxy with handle <" << instance_handle << ":" << native_entity
         << ">");
     }
     return false;
@@ -116,7 +116,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dr_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_datareader_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::register_proxy<
       ::IDL::traits< ::DDS::DataReader>::ref_type,
@@ -132,7 +132,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dw_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_datawriter_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::register_proxy<
       ::IDL::traits< ::DDS::DataWriter>::ref_type,
@@ -148,7 +148,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::sub_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_subscriber_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::register_proxy<
       ::IDL::traits< ::DDS::Subscriber>::ref_type,
@@ -164,7 +164,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::pub_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_publisher_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::register_proxy<
       ::IDL::traits< ::DDS::Publisher>::ref_type,
@@ -180,7 +180,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::tp_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_topic_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     // Let us find first whether we already have a topic proxy for the
     // given native entity
@@ -200,12 +200,12 @@ namespace DDSX11
       if (!ret.second)
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::register_topic_proxy - "
-          "Registering proxy <" << proxy->get_instance_handle () << "> failed");
+          "Registering proxy <" << proxy->get_instance_handle () << ":" << native_entity << "> failed");
         return false;
       }
 
       DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_topic_proxy - "
-        "Registering topic proxy with handle <" << proxy->get_instance_handle () << "> succeeded");
+        "Registering topic proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << "> succeeded");
     }
 
     return true;
@@ -219,7 +219,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dp_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::register_dp_proxy - "
-      "Registering proxy with handle <" << proxy->get_instance_handle () << ">");
+      "Registering proxy with handle <" << proxy->get_instance_handle () << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::register_proxy<
       ::IDL::traits< ::DDS::DomainParticipant>::ref_type,
@@ -235,7 +235,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dr_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_datareader_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::unregister_proxy<DDS_ProxyEntityManager::DataReaderProxies>
       (native_entity, handle, DDS_ProxyEntityManager::dr_proxies);
@@ -249,7 +249,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dw_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_datawriter_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::unregister_proxy<DDS_ProxyEntityManager::DataWriterProxies>
       (native_entity, handle, DDS_ProxyEntityManager::dw_proxies);
@@ -263,7 +263,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::sub_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_subscriber_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::unregister_proxy<DDS_ProxyEntityManager::SubscriberProxies>
       (native_entity, handle, DDS_ProxyEntityManager::sub_proxies);
@@ -277,7 +277,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::pub_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_publisher_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::unregister_proxy<DDS_ProxyEntityManager::PublisherProxies>
       (native_entity, handle, DDS_ProxyEntityManager::pub_proxies);
@@ -291,7 +291,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::tp_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_topic_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     typename TopicProxies::iterator const it = tp_proxies.find (native_entity);
     if (it != tp_proxies.end ())
@@ -300,7 +300,7 @@ namespace DDSX11
       if (refcount == 0)
         {
           DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_topic_proxy - "
-            << "Removed topic proxy with handle <" << handle
+            << "Removed topic proxy with handle <" << handle << ":" << native_entity
             << "> from the list because its refcount dropped to zero");
           tp_proxies.erase (it);
 
@@ -309,14 +309,14 @@ namespace DDSX11
       else
         {
           DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_topic_proxy - "
-            << "Did not remove topic proxy with handle <" << handle
+            << "Did not remove topic proxy with handle <" << handle << ":" << native_entity
             << "> from the list because its refcount dropped to " << refcount);
         }
     }
     else
     {
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::unregister_proxy - "
-        << "Could not find a proxy with handle <" << handle
+        << "Could not find a proxy with handle <" << handle << ":" << native_entity
         << ">");
     }
 
@@ -331,7 +331,7 @@ namespace DDSX11
     std::lock_guard<std::mutex> __guard (DDS_ProxyEntityManager::dp_mutex);
 
     DDSX11_IMPL_LOG_DEBUG ("DDS_ProxyEntityManager::unregister_dp_proxy - "
-      "Unregistering proxy with handle <" << handle << ">");
+      "Unregistering proxy with handle <" << handle << ":" << native_entity << ">");
 
     return DDS_ProxyEntityManager::unregister_proxy<DDS_ProxyEntityManager::DomainParticipantProxies>
       (native_entity, handle, DDS_ProxyEntityManager::dp_proxies);
@@ -407,7 +407,7 @@ namespace DDSX11
     else
     {
       DDSX11_IMPL_LOG_INFO ("DDS_ProxyEntityManager::get_proxy - "
-        << "Could not find a proxy with handle <" << handle
+        << "Could not find a proxy with handle <" << handle << ":" << native_entity
         << ">");
     }
     return proxy;
@@ -520,9 +520,14 @@ namespace DDSX11
   {
     for (auto& it : DDS_ProxyEntityManager::dr_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered DataReader with handle <" << it.first
+        << "Found a registered DataReader with handle <" << handle << ":" << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_DataReader_proxy>::ref_type proxy =
         data_reader_trait::proxy (it.second);
       if (proxy)
@@ -535,9 +540,14 @@ namespace DDSX11
 
     for (auto& it : DDS_ProxyEntityManager::dw_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered DataWriter with handle <" << it.first
+        << "Found a registered DataWriter with handle <" << handle << ":"  << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_DataWriter_proxy>::ref_type proxy =
         data_writer_trait::proxy (it.second);
       if (proxy)
@@ -550,9 +560,14 @@ namespace DDSX11
 
     for (auto& it : DDS_ProxyEntityManager::pub_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered Publisher with handle <" << it.first
+        << "Found a registered Publisher with handle <" << handle << ":"  << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_Publisher_proxy>::ref_type proxy =
         publisher_trait::proxy (it.second);
       if (proxy)
@@ -565,9 +580,14 @@ namespace DDSX11
 
     for (auto& it : DDS_ProxyEntityManager::sub_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered Subscriber with handle <" << it.first
+        << "Found a registered Subscriber with handle <" << handle << ":"  << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_Subscriber_proxy>::ref_type proxy =
         subscriber_trait::proxy (it.second);
       if (proxy)
@@ -580,9 +600,14 @@ namespace DDSX11
 
     for (auto& it : DDS_ProxyEntityManager::tp_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered Topic with handle <" << it.first
+        << "Found a registered Topic with handle <" << handle << ":"  << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_Topic_proxy>::ref_type proxy =
         topic_trait::proxy (it.second.second);
       if (proxy)
@@ -595,9 +620,14 @@ namespace DDSX11
 
     for (auto& it : DDS_ProxyEntityManager::dp_proxies)
     {
+      ::DDS::InstanceHandle_t const handle =
+        ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+          it.first->get_instance_handle ());
+
       DDSX11_IMPL_LOG_ERROR ("DDS_ProxyEntityManager::finalize - "
-        << "Found a registered DomainParticipant with handle <" << it.first
+        << "Found a registered DomainParticipant with handle <" << handle << ":"  << it.first
         << ">. Resetting the registered reference.");
+
       IDL::traits< ::DDSX11::DDS_DomainParticipant_proxy>::ref_type proxy =
         domain_participant_trait::proxy (it.second);
       if (proxy)

--- a/ddsx11/dds/dds_proxy_entity_manager.cpp
+++ b/ddsx11/dds/dds_proxy_entity_manager.cpp
@@ -68,7 +68,7 @@ namespace DDSX11
     }
 
     PROXY_TYPE proxy {};
-    const ::DDS::InstanceHandle_t handle =
+    ::DDS::InstanceHandle_t const handle =
       ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
         native_entity->get_instance_handle ());
 

--- a/ddsx11/dds/dds_proxy_entity_manager.h
+++ b/ddsx11/dds/dds_proxy_entity_manager.h
@@ -5,17 +5,25 @@
  *
  * @brief   Class which manages the C++11 proxies and DDS vendor entities
  *
- *          This way there's no need to create a C++ proxy once a callback from DDS
- *          gets invoked.
- *          Another advantage is that only one proxy represents the native entity.
- *          The C++11 proxies are stored in internal maps for data readers/data
- *          writers/subscribers/publishers/topics/domain participants. This way
- *          narrows are prevented in the critical path.
+ * The concept between the DDSX11 proxies is that there is one DDSX11 proxy
+ * for each native DDS entity. Without this one to one relationship we can have
+ * multiple DDSX11 proxies pointing to the same native DDS entity and this
+ * could result in dangling pointers at the moment the native DDS entity
+ * gets deleted. Some DDS vendors do provide reference counting for their
+ * native entities, but others don't.
  *
- *          The internal maps have the DDS InstanceHandle_t as key.
+ * The C++11 proxies are stored in internal maps for data readers/data
+ * writers/subscribers/publishers/topics/domain participants. This way
+ * narrows are prevented in the critical path.
  *
- *          The maps are the only place in the DDS proxy where a strong reference
- *          is kept!!
+ * The DDS InstanceHandle_t is not guaranteed to be unique within the same
+ * proces, some vendors do have it unique, but others don't have an
+ * id which is only unique within a single domain participant. Because
+ * of this the maps within this class all use the DDS native entity
+ * pointer as key.
+ *
+ * The maps are the only place in the DDS proxy where a strong reference
+ * is kept!!
  *
  * @copyright Copyright (c) Remedy IT Expertise BV
  */
@@ -38,19 +46,6 @@ namespace DDS_Native {
 
 namespace DDSX11
 {
-  /**
-    * @name    CompareHandles
-    * @brief   operator used by the internal maps to compare
-    *          the InstanceHandle_t
-    */
-  struct CompareHandles
-  {
-    bool operator ()(const ::DDS::InstanceHandle_t &h1, const ::DDS::InstanceHandle_t &h2) const
-    {
-      return h1 < h2;
-    }
-  };
-
   class DDSX11_IMPL_Export DDS_ProxyEntityManager final
   {
   public:
@@ -62,99 +57,74 @@ namespace DDSX11
 
     /**
       * @name         register_xxx_proxy
-      * @brief        Storing the given proxy into the corresponding map
+      * @brief        Storing the DDSX11 proxy into the corresponding map
       * @param proxy  The C++11 proxy to store
+      * @param native The pointer to the native DDS entity
       * @retval true  Registering the proxy succeeded
       * @retval false Registering the proxy failed
       */
     //@{
-    static bool
-    register_datareader_proxy (::IDL::traits< ::DDS::DataReader>::ref_type proxy);
+    static bool register_datareader_proxy (::IDL::traits< ::DDS::DataReader>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
 
-    static bool register_datawriter_proxy (::IDL::traits< ::DDS::DataWriter>::ref_type proxy);
+    static bool register_datawriter_proxy (::IDL::traits< ::DDS::DataWriter>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
 
-    static bool register_subscriber_proxy (::IDL::traits< ::DDS::Subscriber>::ref_type proxy);
+    static bool register_subscriber_proxy (::IDL::traits< ::DDS::Subscriber>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
 
-    static bool register_publisher_proxy (::IDL::traits< ::DDS::Publisher>::ref_type proxy);
+    static bool register_publisher_proxy (::IDL::traits< ::DDS::Publisher>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
 
-    static bool register_topic_proxy (::IDL::traits< ::DDS::Topic>::ref_type proxy);
+    static bool register_topic_proxy (::IDL::traits< ::DDS::Topic>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
 
-    static bool register_dp_proxy (::IDL::traits< ::DDS::DomainParticipant>::ref_type proxy);
+    static bool register_dp_proxy (::IDL::traits< ::DDS::DomainParticipant>::ref_type proxy, DDS_Native::DDS::Entity *native_entity);
     //@}
 
     /**
       * @name  unregister_xxx_proxy
-      * @brief Looking up the given proxy and remove it from
+      * @brief Looking up the given DDSX11 proxy and remove it from
       *        the corresponding map
-      * @param handle The instance handle of the proxy to unregister
+      * @param native_entity The pointer to the native DDS entity for which we should unregister the DDSX11 proxy
+      * @param instance_handle The DDS instance handle of the DDS entity, passed here because we can't
+      * assume that it is safe to retrieve it from the @a native_entity at this point anymore
       * @retval true The proxy has been successfully unregistered
       * @retval false The proxy was not found
       */
     //@{
-    static bool
-    unregister_datareader_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_datareader_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
 
-    static bool
-    unregister_datawriter_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_datawriter_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
 
-    static bool
-    unregister_subscriber_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_subscriber_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
 
-    static bool
-    unregister_publisher_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_publisher_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
 
-    static bool
-    unregister_topic_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_topic_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
 
-    static bool
-    unregister_dp_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle);
+    static bool unregister_dp_proxy (DDS_Native::DDS::Entity *native_entity, IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle);
     //@}
 
     /**
       * @name                get_xxx_proxy
-      * @brief               Retrieving the C++11 proxy from the corresponding map
+      * @brief               Retrieving the DDSX11 proxy from the corresponding map
       * @param native_entity The native pointer of which to find the C++11 counterpart
       * @return              The C++11 proxy if found; nullptr otherwise
       */
     //@{
-    static ::IDL::traits< ::DDS::DataReader>::ref_type
-    get_datareader_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::DataReader>::ref_type get_datareader_proxy (DDS_Native::DDS::Entity *native_entity);
 
-    static ::IDL::traits< ::DDS::DataWriter>::ref_type
-    get_datawriter_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::DataWriter>::ref_type get_datawriter_proxy (DDS_Native::DDS::Entity *native_entity);
 
-    static ::IDL::traits< ::DDS::Subscriber>::ref_type
-    get_subscriber_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::Subscriber>::ref_type get_subscriber_proxy (DDS_Native::DDS::Entity *native_entity);
 
-    static ::IDL::traits< ::DDS::Publisher>::ref_type
-    get_publisher_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::Publisher>::ref_type get_publisher_proxy (DDS_Native::DDS::Entity *native_entity);
 
-    static ::IDL::traits< ::DDS::Topic>::ref_type
-    get_topic_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::Topic>::ref_type get_topic_proxy (DDS_Native::DDS::Entity *native_entity);
 
-    static ::IDL::traits< ::DDS::DomainParticipant>::ref_type
-    get_dp_proxy (
-      DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::DomainParticipant>::ref_type get_dp_proxy (DDS_Native::DDS::Entity *native_entity);
 
     /// Search every map for the given entity
-    static ::IDL::traits< ::DDS::Entity>::ref_type
-    get_entity_proxy (
-        DDS_Native::DDS::Entity *native_entity);
+    static ::IDL::traits< ::DDS::Entity>::ref_type get_entity_proxy (DDS_Native::DDS::Entity *native_entity);
     //@}
 
-    static void
-    finalize ();
+    static void finalize ();
 
   private:
     /**
@@ -163,7 +133,8 @@ namespace DDSX11
       *                Stores the C++11 proxy in the given map in a consistent way.
       * @tparam PROXY_TYPE The type of entity to unregister (DataReader/DataWRiter/Topic/...)
       * @tparam PROXY_MAP  The type of the map in which to store the given proxy
-      * @param  proxy   The C++11 proxy to store
+      * @param  proxy   The DDSX11 proxy to store
+      * @param  native  The pointer to the native entity
       * @param  lst     Reference to the map in which to store the proxy
       * @retval true    The registering of the proxy succeeded
       * @retval false   The registering of the proxy failed
@@ -173,6 +144,7 @@ namespace DDSX11
     static bool
     register_proxy (
       PROXY_TYPE proxy,
+      DDS_Native::DDS::Entity *native_entity,
       PROXY_MAP &lst);
 
     /**
@@ -197,7 +169,9 @@ namespace DDSX11
       * @brief         Helper method, preventing double code.
       *                Removes the given proxy from the corresponding list.
       * @tparam PROXY_MAP  The type of the map from which to unregister the given proxy
-      * @param handle  The instance handle of the proxy we need to unregister
+      * @param native_entity  The pointer to the native entity for which we want to unregister the proxy
+      * @param instance_handle The DDS instance handle of the DDS entity, passed here because we can't
+      * assume that it is safe to retrieve it from the @a native_entity at this point anymore
       * @param lst     Reference to the map from which to unregister the proxy
       * @retval true The proxy has been successfully unregistered
       * @retval false The proxy was not found
@@ -205,26 +179,27 @@ namespace DDSX11
     template<typename PROXY_MAP>
     static bool
     unregister_proxy (
-      IDL::traits< ::DDS::InstanceHandle_t>::in_type handle,
+      DDS_Native::DDS::Entity *native_entity,
+      IDL::traits< ::DDS::InstanceHandle_t>::in_type instance_handle,
       PROXY_MAP &lst);
 
     /// Map containing all DataReader C++11 proxies
-    typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DataReader>::ref_type, CompareHandles> DataReaderProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, IDL::traits< ::DDS::DataReader>::ref_type> DataReaderProxies;
     static DataReaderProxies dr_proxies;
     static std::mutex dr_mutex;
 
     /// Map containing all DataWriter C++11 proxies
-    typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DataWriter>::ref_type, CompareHandles> DataWriterProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, IDL::traits< ::DDS::DataWriter>::ref_type> DataWriterProxies;
     static DataWriterProxies dw_proxies;
     static std::mutex dw_mutex;
 
     /// Map containing all Subscriber C++11 proxies
-    typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::Subscriber>::ref_type, CompareHandles> SubscriberProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, IDL::traits< ::DDS::Subscriber>::ref_type> SubscriberProxies;
     static SubscriberProxies sub_proxies;
     static std::mutex sub_mutex;
 
     /// Map containing all Publisher C++11 proxies
-    typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::Publisher>::ref_type, CompareHandles> PublisherProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, IDL::traits< ::DDS::Publisher>::ref_type> PublisherProxies;
     static PublisherProxies pub_proxies;
     static std::mutex pub_mutex;
 
@@ -233,12 +208,12 @@ namespace DDSX11
     /// implementation can return multiple times the same topic for which multiple times the delete_topic
     /// must be called, only for the last instance the unregister will remove it from the map
     typedef std::pair <uint32_t, IDL::traits< ::DDS::Topic>::ref_type> TopicRefcount;
-    typedef std::map< ::DDS::InstanceHandle_t, TopicRefcount, CompareHandles> TopicProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, TopicRefcount> TopicProxies;
     static TopicProxies tp_proxies;
     static std::mutex tp_mutex;
 
     /// Map containing all DomainParticipant C++11 proxies
-    typedef std::map< ::DDS::InstanceHandle_t, IDL::traits< ::DDS::DomainParticipant>::ref_type, CompareHandles> DomainParticipantProxies;
+    typedef std::map<DDS_Native::DDS::Entity *, IDL::traits< ::DDS::DomainParticipant>::ref_type> DomainParticipantProxies;
     static DomainParticipantProxies dp_proxies;
     static std::mutex dp_mutex;
 

--- a/ddsx11/dds/dds_publisher.cpp
+++ b/ddsx11/dds/dds_publisher.cpp
@@ -95,7 +95,7 @@ namespace DDSX11
                                             native_dw);
     if (datawriter)
     {
-      if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter))
+      if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter, native_dw))
         {
           DDSX11_IMPL_LOG_DEBUG ("DDS_Publisher_proxy::create_datawriter - "
             << "Successfully created and registered a DataWriter");
@@ -169,7 +169,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_datawriter_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_datawriter_proxy (native_dw, handle))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_datawriter - "
               << "Error: Can't unregister datawriter proxy for <" << handle << ">");

--- a/ddsx11/dds/dds_publisher.cpp
+++ b/ddsx11/dds/dds_publisher.cpp
@@ -89,8 +89,11 @@ namespace DDSX11
     // of scope.
     listener_guard.release ();
 
+    DDS_Native::DDS::DomainParticipant_var native_dp =
+      this->native_entity ()->get_participant ();
+
     IDL::traits< ::DDS::DataWriter>::ref_type datawriter =
-      DDS_TypeSupport_i::create_datawriter (this->get_participant (),
+      DDS_TypeSupport_i::create_datawriter (native_dp,
                                             a_topic->get_type_name (),
                                             native_dw);
     if (datawriter)

--- a/ddsx11/dds/dds_subscriber.cpp
+++ b/ddsx11/dds/dds_subscriber.cpp
@@ -197,10 +197,13 @@ namespace DDSX11
     DDSX11_IMPL_LOG_DEBUG ("DDS_Subscriber_proxy::create_datareader - "
       << "Successfully created native datareader");
 
+    DDS_Native::DDS::DomainParticipant_var native_dp =
+      this->native_entity ()->get_participant ();
+
     // Create the X11 typed datareader
     IDL::traits< ::DDS::DataReader>::ref_type datareader =
       DDS_TypeSupport_i::create_datareader (
-            this->get_participant (),
+            native_dp,
             a_topic->get_type_name (),
             native_dr);
 

--- a/ddsx11/dds/dds_subscriber.cpp
+++ b/ddsx11/dds/dds_subscriber.cpp
@@ -207,7 +207,7 @@ namespace DDSX11
     if (datareader)
       {
         // Register the fresh created proxy in the proxy entity manager
-        if (DDS_ProxyEntityManager::register_datareader_proxy (datareader))
+        if (DDS_ProxyEntityManager::register_datareader_proxy (datareader, native_dr))
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_Subscriber_proxy::create_datareader - "
               << "Successfully created and registered a datareader.");
@@ -280,7 +280,7 @@ namespace DDSX11
       }
     else
       {
-        if (!DDS_ProxyEntityManager::unregister_datareader_proxy (handle))
+        if (!DDS_ProxyEntityManager::unregister_datareader_proxy (native_dr, handle))
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_DomainParticipant_proxy::delete_datareader - "
               << "Error: Can't unregister datareader proxy for <" << handle << ">");

--- a/ddsx11/dds/dds_type_support.cpp
+++ b/ddsx11/dds/dds_type_support.cpp
@@ -69,7 +69,7 @@ namespace DDSX11
         if (it != entry->second.end ())
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::get_factory_i - "
-            << "A factory for domain participant <" << handle
+            << "A factory for domain participant <" << handle << ":" << dp
             << "> of type <" << type << "> has been found.");
             return it->second->get_factory ();
           }
@@ -77,7 +77,7 @@ namespace DDSX11
 
     DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::get_factory_i - "
       << "A factory for domain participant <"
-      << handle
+      << handle << ":" << dp
       << "> of type <" << type << "> could not be found.");
 
     return {};
@@ -121,7 +121,7 @@ namespace DDSX11
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
               << "Unable to create DomainParticipant entry: type <"
-              << type << "> - DomainParticipant <" << handle
+              << type << "> - DomainParticipant <" << handle << ":" << native_dp
               << ">");
             return false;
           }
@@ -145,7 +145,7 @@ namespace DDSX11
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::register_type - "
               << "Created factory entry for type <" << type << "> for "
-              << "participant <" << handle
+              << "participant <" << handle << ":" << native_dp
               << ">");
             // Returning true in case we first register the type, that way the
             // caller knows we also have to register the type with DDS
@@ -155,7 +155,7 @@ namespace DDSX11
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
               << "Unable to create -new- factory entry type <" << type
-              << "> for participant <" << handle
+              << "> for participant <" << handle << ":" << native_dp
               << ">");
           }
       }
@@ -165,7 +165,7 @@ namespace DDSX11
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::register_type - "
           << "Incremented refcount to <" << refcount
           << "> for type-factory " << "for participant <"
-          << handle << "> since it already exists for "
+          << handle << ":" << native_dp << "> since it already exists for "
           << "type <" << type << ">");
       }
     return retval;
@@ -203,7 +203,7 @@ namespace DDSX11
     if (dp_entry != participant_factories.end ())
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
-          << "Found entry for participant <" << handle
+          << "Found entry for participant <" << handle << ":" << native_dp
           << "> and type <" << type << ">");
         // Found the domain participant
         typefactories::iterator it = dp_entry->second.find (type);
@@ -219,7 +219,7 @@ namespace DDSX11
                 // Erase it from the list will decrement the use_count with one.
                 DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                   << "Decremented refcount on factory for participant <"
-                  << handle
+                  << handle << ":" << native_dp
                   << "> and type <" << type << ">. Refcount dropped to zero");
 
                 it->second = nullptr;
@@ -231,7 +231,7 @@ namespace DDSX11
 
                     DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                       << "Erased participant entry for participant <"
-                      << handle << ">, no type factories left anymore");
+                      << handle << ":" << native_dp << ">, no type factories left anymore");
                   }
               }
             else
@@ -239,21 +239,21 @@ namespace DDSX11
                 DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                   << "Decremented refcount to <" << refcount
                   << "> for factory for participant <"
-                  << handle << "> and type <" << type << ">");
+                  << handle << ":" << native_dp << "> and type <" << type << ">");
               }
           }
         else
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
               << "Could not find the correct factory belonging to participant <"
-              << handle << "> and type <" << type << ">. Unable to remove.");
+              << handle << ":" << native_dp << "> and type <" << type << ">. Unable to remove.");
           }
       }
     else
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
           << "Could not find the entry for participant <"
-          << handle << ">. Unable to remove.");
+          << handle << ":" << native_dp << ">. Unable to remove.");
       }
     return retval;
   }
@@ -275,7 +275,7 @@ namespace DDSX11
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::create_datawriter - "
           << "Type factory found for type <" << type_name << "> for "
-          << "participant <" << handle
+          << "participant <" << handle << ":" << dp
           << ">");
 
         return f->create_datawriter (dw);
@@ -284,7 +284,7 @@ namespace DDSX11
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::create_datawriter - "
           << "Error creating DDS_Native::DDS::DataWriter for type <" << type_name
-          << "> for participant <" << handle
+          << "> for participant <" << handle << ":" << dp
           << ">");
       }
 
@@ -308,7 +308,7 @@ namespace DDSX11
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::create_datareader - "
           << "Created DDS_Native::DDS::DataReader for type <" << type_name
-          << "> for participant <" << handle
+          << "> for participant <" << handle << ":" << dp
           << ">");
 
         return f->create_datareader (dr);
@@ -318,7 +318,7 @@ namespace DDSX11
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::create_datareader - "
           << "Error creating DDS_Native::DDS::DataReader for type <" << type_name
           << "> for participant <"
-          << handle
+          << handle << ":" << dp
           << ">");
       }
 

--- a/ddsx11/dds/dds_type_support.cpp
+++ b/ddsx11/dds/dds_type_support.cpp
@@ -10,12 +10,14 @@
 #include "dds/dds_common.h"
 #include "dds/dds_type_support.h"
 #include "logger/ddsx11_log.h"
+#include "dds/dds_vendor_conversion_traits.h"
+#include "dds/dds_domain_participant.h"
 
 namespace DDSX11
 {
   DDS_TypeFactory_i_ref::DDS_TypeFactory_i_ref (
     std::shared_ptr<DDS_TypeFactory_i> tf)
-    : tf_ (tf)
+    : tf_ (std::move(tf))
   {
     DDSX11_LOG_TRACE ("DDS_TypeFactory_i_ref::DDS_TypeFactory_i_ref");
   }
@@ -47,14 +49,18 @@ namespace DDSX11
 
   std::shared_ptr<DDS_TypeFactory_i>
   DDS_TypeSupport_i::get_factory_i (
-    IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+    DDS_Native::DDS::DomainParticipant* dp,
     const std::string &type)
   {
     DDSX11_LOG_TRACE ("DDS_TypeSupport_i::get_factory_i");
 
     participantfactories::iterator entry =
-      participant_factories.find (
-        dp->get_instance_handle ().value ());
+      participant_factories.find (dp);
+
+    ::DDS::InstanceHandle_t const handle =
+      ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+        dp->get_instance_handle ());
+
     if (entry != participant_factories.end ())
       {
         // We have found the domain participant, now search for a type factory
@@ -63,8 +69,7 @@ namespace DDSX11
         if (it != entry->second.end ())
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::get_factory_i - "
-            << "A factory for domain participant <"
-            << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+            << "A factory for domain participant <" << handle
             << "> of type <" << type << "> has been found.");
             return it->second->get_factory ();
           }
@@ -72,7 +77,7 @@ namespace DDSX11
 
     DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::get_factory_i - "
       << "A factory for domain participant <"
-      << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+      << handle
       << "> of type <" << type << "> could not be found.");
 
     return {};
@@ -86,22 +91,37 @@ namespace DDSX11
   {
     DDSX11_LOG_TRACE ("DDS_TypeSupport_i::register_type");
 
-    participantfactories::iterator dp_entry =
-      participant_factories.find (dp->get_instance_handle ().value ());
+    IDL::traits< ::DDSX11::DDS_DomainParticipant_proxy>::ref_type proxy =
+      domain_participant_trait::proxy (dp);
+    if (!proxy)
+      {
+        DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
+          << "Unable to retrieve the proxy from the provided object reference.");
+        return false;
+      }
+
+    DDS_Native::DDS::DomainParticipant *native_dp = proxy->get_native_entity ();
+    if (!native_dp)
+      {
+        DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
+          << "Unable to retrieve the native domainparticipant from the provided object reference.");
+        return false;
+      }
+
+    ::DDS::InstanceHandle_t const handle = dp->get_instance_handle ();
+
+    participantfactories::iterator dp_entry = participant_factories.find (native_dp);
     if (dp_entry == participant_factories.end ())
       {
         // The domain participant has not been found, insert the domain
         // participant first
-        std::pair<participantfactories::iterator, bool> dp_ret =
-          participant_factories.insert (
-            participantfactories::value_type (
-              dp->get_instance_handle ().value (), typefactories ()));
+        std::pair<participantfactories::iterator, bool> const dp_ret =
+          participant_factories.insert (participantfactories::value_type (native_dp, typefactories ()));
         if (!dp_ret.second)
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
               << "Unable to create DomainParticipant entry: type <"
-              << type << "> - DomainParticipant <"
-              << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+              << type << "> - DomainParticipant <" << handle
               << ">");
             return false;
           }
@@ -125,8 +145,7 @@ namespace DDSX11
           {
             DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::register_type - "
               << "Created factory entry for type <" << type << "> for "
-              << "participant <"
-              << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+              << "participant <" << handle
               << ">");
             // Returning true in case we first register the type, that way the
             // caller knows we also have to register the type with DDS
@@ -136,8 +155,7 @@ namespace DDSX11
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::register_type - "
               << "Unable to create -new- factory entry type <" << type
-              << "> for participant <"
-              << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+              << "> for participant <" << handle
               << ">");
           }
       }
@@ -147,8 +165,7 @@ namespace DDSX11
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::register_type - "
           << "Incremented refcount to <" << refcount
           << "> for type-factory " << "for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
-          << "> since it already exists for "
+          << handle << "> since it already exists for "
           << "type <" << type << ">");
       }
     return retval;
@@ -161,15 +178,32 @@ namespace DDSX11
   {
     DDSX11_LOG_TRACE ("DDS_TypeSupport_i::unregister_type");
 
+    IDL::traits< ::DDSX11::DDS_DomainParticipant_proxy>::ref_type proxy =
+      domain_participant_trait::proxy (dp);
+    if (!proxy)
+      {
+        DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
+          << "Unable to retrieve the proxy from the provided object reference.");
+        return false;
+      }
+
+    DDS_Native::DDS::DomainParticipant *native_dp = proxy->get_native_entity ();
+    if (!native_dp)
+      {
+        DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
+          << "Unable to retrieve the native domainparticipant from the provided object reference.");
+        return false;
+      }
+
     bool retval = false;
-    participantfactories::iterator dp_entry =
-      participant_factories.find (dp->get_instance_handle().value ());
+    participantfactories::iterator dp_entry = participant_factories.find (native_dp);
+
+    ::DDS::InstanceHandle_t const handle = dp->get_instance_handle ();
 
     if (dp_entry != participant_factories.end ())
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
-          << "Found entry for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+          << "Found entry for participant <" << handle
           << "> and type <" << type << ">");
         // Found the domain participant
         typefactories::iterator it = dp_entry->second.find (type);
@@ -185,7 +219,7 @@ namespace DDSX11
                 // Erase it from the list will decrement the use_count with one.
                 DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                   << "Decremented refcount on factory for participant <"
-                  << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+                  << handle
                   << "> and type <" << type << ">. Refcount dropped to zero");
 
                 it->second = nullptr;
@@ -197,8 +231,7 @@ namespace DDSX11
 
                     DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                       << "Erased participant entry for participant <"
-                      << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
-                      << ">, no type factories left anymore");
+                      << handle << ">, no type factories left anymore");
                   }
               }
             else
@@ -206,43 +239,43 @@ namespace DDSX11
                 DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::unregister_type - "
                   << "Decremented refcount to <" << refcount
                   << "> for factory for participant <"
-                  << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
-                  << "> and type <" << type << ">");
+                  << handle << "> and type <" << type << ">");
               }
           }
         else
           {
             DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
               << "Could not find the correct factory belonging to participant <"
-              << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
-              << "> and type <" << type << ">. Unable to remove.");
+              << handle << "> and type <" << type << ">. Unable to remove.");
           }
       }
     else
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::unregister_type - "
           << "Could not find the entry for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
-          << ">. Unable to remove.");
+          << handle << ">. Unable to remove.");
       }
     return retval;
   }
 
   IDL::traits< ::DDS::DataWriter>::ref_type
   DDS_TypeSupport_i::create_datawriter (
-    IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+    DDS_Native::DDS::DomainParticipant* dp,
     const std::string& type_name,
     DDS_Native::DDS::DataWriter* dw)
   {
     DDSX11_LOG_TRACE ("DDS_TypeSupport_i::create_datawriter");
+
+    ::DDS::InstanceHandle_t const handle =
+      ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+        dp->get_instance_handle ());
 
     std::shared_ptr<DDS_TypeFactory_i> f = get_factory_i (dp, type_name);
     if (f)
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::create_datawriter - "
           << "Type factory found for type <" << type_name << "> for "
-          << "participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+          << "participant <" << handle
           << ">");
 
         return f->create_datawriter (dw);
@@ -251,29 +284,31 @@ namespace DDSX11
       {
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::create_datawriter - "
           << "Error creating DDS_Native::DDS::DataWriter for type <" << type_name
-          << "> for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+          << "> for participant <" << handle
           << ">");
       }
 
-    return nullptr;
+    return {};
   }
 
   IDL::traits< ::DDS::DataReader>::ref_type
   DDS_TypeSupport_i::create_datareader (
-    IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+    DDS_Native::DDS::DomainParticipant* dp,
     const std::string& type_name,
     DDS_Native::DDS::DataReader* dr)
   {
     DDSX11_LOG_TRACE ("DDS_TypeSupport_i::create_datareader");
+
+    ::DDS::InstanceHandle_t const handle =
+      ::DDSX11::traits< ::DDS::InstanceHandle_t>::retn (
+        dp->get_instance_handle ());
 
     std::shared_ptr<DDS_TypeFactory_i> f = get_factory_i (dp, type_name);
     if (f)
       {
         DDSX11_IMPL_LOG_DEBUG ("DDS_TypeSupport_i::create_datareader - "
           << "Created DDS_Native::DDS::DataReader for type <" << type_name
-          << "> for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+          << "> for participant <" << handle
           << ">");
 
         return f->create_datareader (dr);
@@ -283,11 +318,11 @@ namespace DDSX11
         DDSX11_IMPL_LOG_ERROR ("DDS_TypeSupport_i::create_datareader - "
           << "Error creating DDS_Native::DDS::DataReader for type <" << type_name
           << "> for participant <"
-          << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
+          << handle
           << ">");
       }
 
-    return nullptr;
+    return {};
   }
 
   void

--- a/ddsx11/dds/dds_type_support.cpp
+++ b/ddsx11/dds/dds_type_support.cpp
@@ -13,10 +13,6 @@
 
 namespace DDSX11
 {
-  DDS_TypeFactory_i::~DDS_TypeFactory_i ()
-  {
-  }
-
   DDS_TypeFactory_i_ref::DDS_TypeFactory_i_ref (
     std::shared_ptr<DDS_TypeFactory_i> tf)
     : tf_ (tf)
@@ -79,7 +75,7 @@ namespace DDSX11
       << IDL::traits< ::DDS::Entity>::write<entity_formatter> (dp)
       << "> of type <" << type << "> could not be found.");
 
-    return nullptr;
+    return {};
   }
 
   bool

--- a/ddsx11/dds/dds_type_support.h
+++ b/ddsx11/dds/dds_type_support.h
@@ -31,7 +31,7 @@ namespace DDSX11
   {
   public:
     DDS_TypeFactory_i () = default;
-    virtual ~DDS_TypeFactory_i ();
+    virtual ~DDS_TypeFactory_i () = default;
 
     virtual IDL::traits< ::DDS::DataWriter>::ref_type
     create_datawriter (DDS_Native::DDS::DataWriter* dw) = 0;

--- a/ddsx11/dds/dds_type_support.h
+++ b/ddsx11/dds/dds_type_support.h
@@ -21,6 +21,7 @@ namespace DDS_Native {
   namespace DDS {
     class DataWriter;
     class DataReader;
+    class DomainParticipant;
   }
 }
 #endif /* DDSX11_HAS_VENDOR_TYPEDEFS */
@@ -117,7 +118,7 @@ namespace DDSX11
       */
     static IDL::traits< ::DDS::DataWriter>::ref_type
     create_datawriter (
-      IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+      DDS_Native::DDS::DomainParticipant* dp,
       const std::string& type_name,
       DDS_Native::DDS::DataWriter* dw);
     /**
@@ -125,7 +126,7 @@ namespace DDSX11
       */
     static IDL::traits< ::DDS::DataReader>::ref_type
     create_datareader (
-      IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+      DDS_Native::DDS::DomainParticipant* dp,
       const std::string& type_name,
       DDS_Native::DDS::DataReader* dr);
 
@@ -144,12 +145,7 @@ namespace DDSX11
 
     /// For each domain participant we store a map with type factories for the
     /// types that participant has
-#if (DDSX11_NDDS==1)
-    typedef ::DDS::octet_value instance_handle_type;
-#else
-    typedef int32_t instance_handle_type;
-#endif
-    typedef std::map<instance_handle_type, typefactories> participantfactories;
+    typedef std::map<DDS_Native::DDS::DomainParticipant*, typefactories> participantfactories;
 
     static participantfactories participant_factories;
 
@@ -157,7 +153,7 @@ namespace DDSX11
       * Searches for a TypeFactory, based on a type and DomainParticipant
       */
     static std::shared_ptr<DDS_TypeFactory_i> get_factory_i (
-      IDL::traits< ::DDS::DomainParticipant>::ref_type dp,
+      DDS_Native::DDS::DomainParticipant* dp,
       const std::string &type);
   };
 }

--- a/ddsx11/tests/type_support/main.cpp
+++ b/ddsx11/tests/type_support/main.cpp
@@ -64,18 +64,24 @@ int main (int , char **)
         pf->create_participant (domain_id, qos, nullptr, ::DDS::STATUS_MASK_NONE);
       if (!dp1)
         {
-          DDSX11_TEST_ERROR
-            << "ERROR - Could not create DP1" << std::endl;
+          DDSX11_TEST_ERROR << "ERROR - Could not create DP1" << std::endl;
           ++ret;
+        }
+      else
+        {
+          DDSX11_TEST_DEBUG << "Created DP1" << std::endl;
         }
 
       IDL::traits< ::DDS::DomainParticipant>::ref_type dp2 =
         pf->create_participant (domain_id, qos, nullptr, ::DDS::STATUS_MASK_NONE);
       if (!dp2)
         {
-          DDSX11_TEST_ERROR
-            << "ERROR - Could not create DP2" << std::endl;
+          DDSX11_TEST_ERROR << "ERROR - Could not create DP2" << std::endl;
           ++ret;
+        }
+      else
+        {
+          DDSX11_TEST_DEBUG << "Created DP2" << std::endl;
         }
 
       std::string const type1 ("DataType1");
@@ -250,8 +256,23 @@ int main (int , char **)
         }
 
       /// No need to remove f1, f2, and f3 since ::close will remove them.
-      pf->delete_participant(dp1);
-      pf->delete_participant(dp2);
+      if (pf->delete_participant(dp1) != ::DDS::RETCODE_OK)
+        {
+          DDSX11_TEST_ERROR << "ERROR - Error deleting dp1 " << std::endl;
+        }
+      else
+        {
+          DDSX11_TEST_DEBUG << "Deleted dp1" << std::endl;
+        }
+
+      if (pf->delete_participant(dp2) != ::DDS::RETCODE_OK)
+        {
+          DDSX11_TEST_ERROR << "ERROR - Error deleting dp2 " << std::endl;
+        }
+      else
+        {
+          DDSX11_TEST_DEBUG << "Deleted dp2" << std::endl;
+        }
 
       pf->finalize_instance ();
     }

--- a/ddsx11/vendors/ndds/dds/ndds_domain_participant.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_domain_participant.cpp
@@ -82,7 +82,7 @@ namespace DDSX11
 
       if (publisher)
         {
-          if (DDS_ProxyEntityManager::register_publisher_proxy (publisher))
+          if (DDS_ProxyEntityManager::register_publisher_proxy (publisher, native_pub))
             {
               DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_publisher_with_profile <"
                 << qos_profile << "> - Successfully created and registered a Publisher.");
@@ -154,7 +154,7 @@ namespace DDSX11
       if (subscriber)
         {
           // Register the fresh created proxy in the proxy entity manager
-          if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber))
+          if (DDS_ProxyEntityManager::register_subscriber_proxy (subscriber, native_sub))
             {
               DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_subscriber_with_profile <"
                 << qos_profile << "> - Successfully created and registered a subscriber.");
@@ -246,7 +246,7 @@ namespace DDSX11
 
       if (topic_reference)
         {
-          if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference))
+          if (DDS_ProxyEntityManager::register_topic_proxy (topic_reference, dds_tp))
             {
               DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipant_proxy::create_topic_with_profile - "
                 << "Successfully created and registered a topic.");

--- a/ddsx11/vendors/ndds/dds/ndds_domain_participant_factory.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_domain_participant_factory.cpp
@@ -91,7 +91,7 @@ namespace DDSX11
       if (retval)
         {
           // Register the fresh created proxy in the proxy entity manager
-          if (DDS_ProxyEntityManager::register_dp_proxy (retval))
+          if (DDS_ProxyEntityManager::register_dp_proxy (retval, dds_dp))
             {
               DDSX11_IMPL_LOG_DEBUG ("NDDS_DomainParticipantFactory_proxy::create_participant_with_profile <"
                 << qos_profile << "> - Successfully created and registered a DomainParticipant "

--- a/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
@@ -89,7 +89,7 @@ namespace DDSX11
 
       if (datawriter)
       {
-        if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter))
+        if (DDS_ProxyEntityManager::register_datawriter_proxy (datawriter, native_dw))
         {
           DDSX11_IMPL_LOG_DEBUG ("NDDS_Publisher_proxy::create_datawriter_with_profile - "
             << "Successfully created and registered a datawriter with profile <"

--- a/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_publisher.cpp
@@ -82,8 +82,11 @@ namespace DDSX11
       // of scope.
       proxy_dwl.release ();
 
+      DDS_Native::DDS::DomainParticipant_var native_dp =
+        this->native_entity ()->get_participant ();
+
       IDL::traits< ::DDS::DataWriter>::ref_type datawriter =
-        DDS_TypeSupport_i::create_datawriter (this->get_participant (),
+        DDS_TypeSupport_i::create_datawriter (native_dp,
                                               a_topic->get_type_name (),
                                               native_dw);
 

--- a/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
@@ -149,7 +149,7 @@ namespace DDSX11
       if (datareader)
         {
           // Register the fresh created proxy in the proxy entity manager
-          if (DDS_ProxyEntityManager::register_datareader_proxy (datareader))
+          if (DDS_ProxyEntityManager::register_datareader_proxy (datareader, native_dr))
           {
             DDSX11_IMPL_LOG_DEBUG ("NDDS_Subscriber_proxy::create_datareader_with_profile - "
               << "Successfully created and registered a datareader with profile <"

--- a/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
+++ b/ddsx11/vendors/ndds/dds/ndds_subscriber.cpp
@@ -139,10 +139,13 @@ namespace DDSX11
           "Successfully created native datareader with profile <"
           << qos_profile << ">");
 
+      DDS_Native::DDS::DomainParticipant_var native_dp =
+        this->native_entity ()->get_participant ();
+
       // Create the X11 typed data reader
       IDL::traits< ::DDS::DataReader>::ref_type datareader =
         DDS_TypeSupport_i::create_datareader (
-              this->get_participant (),
+              native_dp,
               a_topic->get_type_name (),
               native_dr);
 


### PR DESCRIPTION
The DDS::InstanceHandle_t isn't unique (see #192), because of that switching to use the native DDS entity pointer as key for our internal maps