### PR TITLE
Remove DDS::InstanceHandle_t from the logging of a DDS instance handl…

### DIFF
--- a/ddsx11/vendors/ndds/idl/dds_vendor_log_formatters.h
+++ b/ddsx11/vendors/ndds/idl/dds_vendor_log_formatters.h
@@ -98,7 +98,7 @@ struct instance_handle_formatter
       OS& os_,
       ::DDS::InstanceHandle_t const &val_)
   {
-    os_ << "DDS::InstanceHandle_t{";
+    os_ << "{";
     for (uint32_t i = 0; i < 4; ++i)
     {
       uint32_t idx = i*4;


### PR DESCRIPTION
…e, we don't add that with OpenDDS and the logging of a DDS Instance Handle is already pretty unique so it can be easily searched

    * ddsx11/vendors/ndds/idl/dds_vendor_log_formatters.h: