### PR TITLE
Add IDL test example where IDL module name is escaped, currently does…

### DIFF
--- a/connectors/dds4ccm/tests/idl_conversion/data/idl_conversion.idl
+++ b/connectors/dds4ccm/tests/idl_conversion/data/idl_conversion.idl
@@ -225,6 +225,17 @@ module Escaping
     string bar;
   };
 };
+
+module Foo
+{
+  module _ATTRIBUTE
+  {
+    struct TopicA
+    {
+      string a;
+    };  //@TopLevel()
+  };
+};
 */
 
 // Test a module with only non-DDS translatable types/constants


### PR DESCRIPTION
…n't work yet with RTI Connext DDS