### PR TITLE
Make use of IDL::traits<>::make_reference.

### DIFF
--- a/ridlbe/ccmx11/templates/comp_exec/src/component.erb
+++ b/ridlbe/ccmx11/templates/comp_exec/src/component.erb
@@ -70,7 +70,7 @@ namespace <%= executor_cxx_namespace %>
 % write_regen_section(_regen_marker+"[get_#{_p.lem_name}]", indent: 1) do
     if (!this-><%= _p.cxxname %>_)
     {
-      this-><%= _p.cxxname %>_ = CORBA::make_reference <<%= _p.lem_name %>_exec_i> (this->context_);
+      this-><%= _p.cxxname %>_ = IDL::traits< <%= _p.interface_type.scoped_ccm_name %>>::make_reference <<%= _p.lem_name %>_exec_i> (this->context_);
     }
     return this-><%= _p.cxxname %>_;
 % end
@@ -107,6 +107,6 @@ extern "C" void
 create_<%= scoped_name.scope_to_cxxname %>_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = CORBA::make_reference < <%= executor_cxx_namespace %>::<%= lem_name %>_exec_i > ();
+  component = IDL::traits< <%= scoped_ccm_name %>>::make_reference < <%= executor_cxx_namespace %>::<%= lem_name %>_exec_i > ();
 }
 % end

--- a/ridlbe/ccmx11/templates/comp_exec/src/component.erb
+++ b/ridlbe/ccmx11/templates/comp_exec/src/component.erb
@@ -107,6 +107,6 @@ extern "C" void
 create_<%= scoped_name.scope_to_cxxname %>_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = IDL::traits< <%= scoped_ccm_name %>>::make_reference < <%= executor_cxx_namespace %>::<%= lem_name %>_exec_i > ();
+  component = IDL::traits< <%= scoped_ccm_name %>>::make_reference <<%= executor_cxx_namespace %>::<%= lem_name %>_exec_i> ();
 }
 % end

--- a/tests/apc/extended-sync/components/dulicate_sender/hello_another_exec.cpp
+++ b/tests/apc/extended-sync/components/dulicate_sender/hello_another_exec.cpp
@@ -101,7 +101,7 @@ extern "C" void
 create_Hello_Sender_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = IDL::traits< ::Hello::CCM_Sender>::make_reference < Hello_Sender_Impl::Sender_exec_i > ();
+  component = IDL::traits< ::Hello::CCM_Sender>::make_reference <Hello_Sender_Impl::Sender_exec_i> ();
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_another_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/dulicate_sender/hello_another_exec.cpp
+++ b/tests/apc/extended-sync/components/dulicate_sender/hello_another_exec.cpp
@@ -101,7 +101,7 @@ extern "C" void
 create_Hello_Sender_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = CORBA::make_reference <Hello_Sender_Impl::Sender_exec_i> ();
+  component = IDL::traits< ::Hello::CCM_Sender>::make_reference < Hello_Sender_Impl::Sender_exec_i > ();
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_another_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
+++ b/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
@@ -79,7 +79,7 @@ namespace Hello_Receiver_Impl
     IDL::traits< ::Hello::CCM_Receiver_Context>::ref_type context)
     : context_ (std::move (context))
   {
-    this->control_ = CORBA::make_reference<TheStateKeeper> ();
+    this->control_ = IDL::traits< ::Hello::StateController>::make_reference<TheStateKeeper> ();
   }
   //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_foo_exec_i[ctor]
 
@@ -224,7 +224,7 @@ namespace Hello_Receiver_Impl
   //@@{__RIDL_REGEN_MARKER__} - BEGIN : Hello_Receiver_Impl::Receiver_exec_i[get_do_my_foo]
     if (!this->do_my_foo_)
     {
-      this->do_my_foo_ = CORBA::make_reference <do_my_foo_exec_i> (this->context_);
+      this->do_my_foo_ = IDL::traits< ::Hello::CCM_MyFoo>::make_reference <do_my_foo_exec_i> (this->context_);
     }
     return this->do_my_foo_;
   //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[get_do_my_foo]
@@ -252,7 +252,7 @@ extern "C" void
 create_Hello_Receiver_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = CORBA::make_reference <Hello_Receiver_Impl::Receiver_exec_i> ();
+  component = IDL::traits< ::Hello::CCM_Receiver>::make_reference < Hello_Receiver_Impl::Receiver_exec_i > ();
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_receiver_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
+++ b/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
@@ -253,7 +253,6 @@ create_Hello_Receiver_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
   component = IDL::traits< ::Hello::CCM_Receiver>::make_reference <Hello_Receiver_Impl::Receiver_exec_i> ();
-``
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_receiver_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
+++ b/tests/apc/extended-sync/components/receiver/hello_receiver_exec.cpp
@@ -252,7 +252,8 @@ extern "C" void
 create_Hello_Receiver_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = IDL::traits< ::Hello::CCM_Receiver>::make_reference < Hello_Receiver_Impl::Receiver_exec_i > ();
+  component = IDL::traits< ::Hello::CCM_Receiver>::make_reference <Hello_Receiver_Impl::Receiver_exec_i> ();
+``
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_receiver_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/sender/hello_sender_exec.cpp
+++ b/tests/apc/extended-sync/components/sender/hello_sender_exec.cpp
@@ -145,7 +145,7 @@ extern "C" void
 create_Hello_Sender_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = CORBA::make_reference <Hello_Sender_Impl::Sender_exec_i> ();
+  component = IDL::traits< ::Hello::CCM_Sender>::make_reference < Hello_Sender_Impl::Sender_exec_i > ();
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_sender_impl.cpp[Footer]

--- a/tests/apc/extended-sync/components/sender/hello_sender_exec.cpp
+++ b/tests/apc/extended-sync/components/sender/hello_sender_exec.cpp
@@ -145,7 +145,7 @@ extern "C" void
 create_Hello_Sender_Impl (
   IDL::traits<Components::EnterpriseComponent>::ref_type& component)
 {
-  component = IDL::traits< ::Hello::CCM_Sender>::make_reference < Hello_Sender_Impl::Sender_exec_i > ();
+  component = IDL::traits< ::Hello::CCM_Sender>::make_reference <Hello_Sender_Impl::Sender_exec_i> ();
 }
 //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl[factory]
 //@@{__RIDL_REGEN_MARKER__} - BEGIN : hello_sender_impl.cpp[Footer]


### PR DESCRIPTION
Generates component exec without CORBA::make_reference.