### PR TITLE
Exit the dds4ccm latency tests with an error when the test is running more than 6 …

### DIFF
--- a/connectors/dds4ccm/tests/minimal_latency/components/receiver/latency_receiver_exec.h
+++ b/connectors/dds4ccm/tests/minimal_latency/components/receiver/latency_receiver_exec.h
@@ -224,7 +224,7 @@ namespace Test_Receiver_Impl
     /** @name User defined private operations. */
     //@{
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test_Receiver_Impl::Receiver_exec_i[user_private_ops]
-    void start (void);
+    void start ();
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Receiver_Impl::Receiver_exec_i[user_private_ops]
     //@}
 

--- a/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.cpp
+++ b/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.cpp
@@ -477,7 +477,7 @@ namespace Test_Sender_Impl
   }
 
   void
-  Sender_exec_i::calc_results (void)
+  Sender_exec_i::calc_results ()
   {
     if (this->iteration_nr_ == 0)
       return; // ignore first iteration
@@ -652,7 +652,7 @@ namespace Test_Sender_Impl
   }
 
   void
-  Sender_exec_i::calculate_clock_overhead (void)
+  Sender_exec_i::calculate_clock_overhead ()
   {
     int num_of_loops_clock = 320;
     uint64_t begin_time = 0;
@@ -667,7 +667,7 @@ namespace Test_Sender_Impl
   }
 
   void
-  Sender_exec_i::init_values (void)
+  Sender_exec_i::init_values ()
   {
     this->duration_times_.reset (new uint64_t[this->samples_]);
     this->iteration_results_.reset (new IterationResult[this->iterations_]);

--- a/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.h
+++ b/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.h
@@ -402,11 +402,11 @@ namespace Test_Sender_Impl
     /** @name User defined private operations. */
     //@{
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Test_Sender_Impl::Sender_exec_i[user_private_ops]
-    void start (void);
-    void calc_results (void);
-    void reset_results (void);
-    void init_values (void);
-    void calculate_clock_overhead (void);
+    void start ();
+    void calc_results ();
+    void reset_results ();
+    void init_values ();
+    void calculate_clock_overhead ();
     void record_time (uint64_t receive_time);
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Sender_Impl::Sender_exec_i[user_private_ops]
     //@}

--- a/connectors/dds4ccm/tests/minimal_latency/descriptors/latencydatalibrary.xml
+++ b/connectors/dds4ccm/tests/minimal_latency/descriptors/latencydatalibrary.xml
@@ -34,6 +34,7 @@
         </reliability>
         <history>
           <kind>KEEP_LAST_HISTORY_QOS</kind>
+          <depth>1</depth>
         </history>
         <durability>
           <kind>VOLATILE_DURABILITY_QOS</kind>

--- a/connectors/dds4ccm/tests/minimal_latency/descriptors/latencydatalibrary.xml
+++ b/connectors/dds4ccm/tests/minimal_latency/descriptors/latencydatalibrary.xml
@@ -13,13 +13,13 @@
         <reliability>
           <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
         </reliability>
+        <durability>
+          <kind>VOLATILE_DURABILITY_QOS</kind>
+        </durability>
         <history>
           <kind>KEEP_LAST_HISTORY_QOS</kind>
           <depth>1</depth>
         </history>
-        <durability>
-          <kind>VOLATILE_DURABILITY_QOS</kind>
-        </durability>
         <resource_limits>
           <max_instances>1</max_instances>
           <initial_instances>1</initial_instances>
@@ -34,8 +34,10 @@
         </reliability>
         <history>
           <kind>KEEP_LAST_HISTORY_QOS</kind>
-          <depth>1</depth>
         </history>
+        <durability>
+          <kind>VOLATILE_DURABILITY_QOS</kind>
+        </durability>
         <resource_limits>
           <initial_samples>100</initial_samples>
           <initial_instances>1</initial_instances>
@@ -43,9 +45,6 @@
           <max_instances>1</max_instances>
           <max_samples_per_instance>LENGTH_UNLIMITED</max_samples_per_instance>
         </resource_limits>
-        <durability>
-          <kind>VOLATILE_DURABILITY_QOS</kind>
-        </durability>
       </datareader_qos>
     </qos_profile>
 </dds>


### PR DESCRIPTION
…minutes

    * connectors/dds4ccm/tests/minimal_latency/descriptors/latencydatalibrary.xml:
    * connectors/dds4ccm/tests/minimal_latency/descriptors/run_test.pl: