### PR TITLE
Use override for the destructor instead of virtual

### DIFF
--- a/brix/ciaox11/apc/recipes/dataidl.rb
+++ b/brix/ciaox11/apc/recipes/dataidl.rb
@@ -206,7 +206,7 @@ module AxciomaPC
         end
       end
 
-      # process colected dependencies for included IDL
+      # process collected dependencies for included IDL
       mpc_file[:idl_gen].add_dependencies(project_dependencies, :idl_gen)
       if mpc_stub_proj = mpc_file[:stub]
         mpc_stub_proj.add_dependencies(project_dependencies, :stub)

--- a/connectors/dds4ccm/examples/idl/receiver/idl_example_receiver_exec.h
+++ b/connectors/dds4ccm/examples/idl/receiver/idl_example_receiver_exec.h
@@ -52,7 +52,7 @@ namespace Example_BasicSubscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Example_BasicSubscriber_comp_Impl::CA1DataSub_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~CA1DataSub_data_listener_exec_i ();
+    ~CA1DataSub_data_listener_exec_i () override;
 
     /** @name Operations from ::Example::CA1_conn::CCM_Listener */
     //@{
@@ -109,7 +109,7 @@ namespace Example_BasicSubscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Example_BasicSubscriber_comp_Impl::CA1DataSub_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~CA1DataSub_status_exec_i ();
+    ~CA1DataSub_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -161,7 +161,7 @@ namespace Example_BasicSubscriber_comp_Impl
     BasicSubscriber_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Example_BasicSubscriber_comp_Impl::BasicSubscriber_comp_exec_i[ctor]
     /// Destructor
-    virtual ~BasicSubscriber_comp_exec_i ();
+    ~BasicSubscriber_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/examples/idl/sender/idl_example_sender_exec.h
+++ b/connectors/dds4ccm/examples/idl/sender/idl_example_sender_exec.h
@@ -52,7 +52,7 @@ namespace Example_BasicPublisher_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Example_BasicPublisher_comp_Impl::CA1DataPub_CSL_exec_i[ctor]
 
     /// Destructor
-    virtual ~CA1DataPub_CSL_exec_i ();
+    ~CA1DataPub_CSL_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -125,7 +125,7 @@ namespace Example_BasicPublisher_comp_Impl
     BasicPublisher_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Example_BasicPublisher_comp_Impl::BasicPublisher_comp_exec_i[ctor]
     /// Destructor
-    virtual ~BasicPublisher_comp_exec_i ();
+    ~BasicPublisher_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/examples/shapes_asm/shapes_control_comp/src/shapes_control_comp_exec.h
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_control_comp/src/shapes_control_comp_exec.h
@@ -47,7 +47,7 @@ namespace Shapes_Control_comp_Impl
     Control_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Control_comp_Impl::Control_comp_exec_i[ctor]
     /// Destructor
-    virtual ~Control_comp_exec_i ();
+    ~Control_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/examples/shapes_asm/shapes_receiver_comp/src/shapes_receiver_comp_exec.h
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_receiver_comp/src/shapes_receiver_comp_exec.h
@@ -51,7 +51,7 @@ namespace Shapes_Receiver_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Receiver_comp_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_Listener */
     //@{
@@ -107,7 +107,7 @@ namespace Shapes_Receiver_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Receiver_comp_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -159,7 +159,7 @@ namespace Shapes_Receiver_comp_Impl
     Receiver_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Receiver_comp_Impl::Receiver_comp_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_comp_exec_i ();
+    ~Receiver_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/examples/shapes_asm/shapes_sender_comp/src/shapes_sender_comp_exec.h
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_sender_comp/src/shapes_sender_comp_exec.h
@@ -52,7 +52,7 @@ namespace Shapes_Sender_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Sender_comp_Impl::control_exec_i[ctor]
 
     /// Destructor
-    virtual ~control_exec_i ();
+    ~control_exec_i () override;
 
     /** @name Operations from ::Shapes::CCM_Control_obj */
     //@{
@@ -103,7 +103,7 @@ namespace Shapes_Sender_comp_Impl
     Sender_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Shapes_Sender_comp_Impl::Sender_comp_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_comp_exec_i ();
+    ~Sender_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/apc_event_defaults/components/receiver/event_receiver_exec.h
+++ b/connectors/dds4ccm/tests/apc/apc_event_defaults/components/receiver/event_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Data_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::Data::EventInterface::CCM_Listener */
     //@{
@@ -104,7 +104,7 @@ namespace Data_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -156,7 +156,7 @@ namespace Data_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/apc_event_defaults/components/sender/event_sender_exec.h
+++ b/connectors/dds4ccm/tests/apc/apc_event_defaults/components/sender/event_sender_exec.h
@@ -48,7 +48,7 @@ namespace Data_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Sender_Impl::connector_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_exec_i ();
+    ~connector_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -120,7 +120,7 @@ namespace Data_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/apc_event_extended/components/receiver/event_receiver_exec.h
+++ b/connectors/dds4ccm/tests/apc/apc_event_extended/components/receiver/event_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Data_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::Data::EventInterface::CCM_Listener */
     //@{
@@ -104,7 +104,7 @@ namespace Data_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -156,7 +156,7 @@ namespace Data_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/apc_event_extended/components/sender/event_sender_exec.h
+++ b/connectors/dds4ccm/tests/apc/apc_event_extended/components/sender/event_sender_exec.h
@@ -48,7 +48,7 @@ namespace Data_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Sender_Impl::connector_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_exec_i ();
+    ~connector_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -120,7 +120,7 @@ namespace Data_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Data_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/gen_comp/components/publisher/publisher_exec.h
+++ b/connectors/dds4ccm/tests/apc/gen_comp/components/publisher/publisher_exec.h
@@ -47,7 +47,7 @@ namespace publisher_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : publisher_comp_Impl::connector_status_ShapeType_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_ShapeType_exec_i ();
+    ~connector_status_ShapeType_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -119,7 +119,7 @@ namespace publisher_comp_Impl
     publisher_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : publisher_comp_Impl::publisher_comp_exec_i[ctor]
     /// Destructor
-    virtual ~publisher_comp_exec_i ();
+    ~publisher_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/gen_comp/components/subscriber/subscriber_exec.h
+++ b/connectors/dds4ccm/tests/apc/gen_comp/components/subscriber/subscriber_exec.h
@@ -48,7 +48,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_Listener */
     //@{
@@ -104,7 +104,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -160,7 +160,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_read_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_read_status_exec_i ();
+    ~info_read_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -216,7 +216,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_get_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_get_status_exec_i ();
+    ~info_get_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -272,7 +272,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_data_listener_exec_i ();
+    ~info_state_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_StateListener */
     //@{
@@ -338,7 +338,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_status_exec_i ();
+    ~info_state_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -390,7 +390,7 @@ namespace subscriber_comp_Impl
     subscriber_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::subscriber_comp_exec_i[ctor]
     /// Destructor
-    virtual ~subscriber_comp_exec_i ();
+    ~subscriber_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/gen_comp_only/components/publisher/publisher_exec.h
+++ b/connectors/dds4ccm/tests/apc/gen_comp_only/components/publisher/publisher_exec.h
@@ -47,7 +47,7 @@ namespace publisher_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : publisher_comp_Impl::connector_status_ShapeType_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_ShapeType_exec_i ();
+    ~connector_status_ShapeType_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -119,7 +119,7 @@ namespace publisher_comp_Impl
     publisher_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : publisher_comp_Impl::publisher_comp_exec_i[ctor]
     /// Destructor
-    virtual ~publisher_comp_exec_i ();
+    ~publisher_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/apc/gen_comp_only/components/subscriber/subscriber_exec.h
+++ b/connectors/dds4ccm/tests/apc/gen_comp_only/components/subscriber/subscriber_exec.h
@@ -48,7 +48,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_Listener */
     //@{
@@ -104,7 +104,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -160,7 +160,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_read_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_read_status_exec_i ();
+    ~info_read_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -216,7 +216,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_get_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_get_status_exec_i ();
+    ~info_get_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -272,7 +272,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_data_listener_exec_i ();
+    ~info_state_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_StateListener */
     //@{
@@ -338,7 +338,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_status_exec_i ();
+    ~info_state_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -394,7 +394,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_2_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_2_data_listener_exec_i ();
+    ~info_out_2_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_Listener */
     //@{
@@ -450,7 +450,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_out_2_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_2_status_exec_i ();
+    ~info_out_2_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -506,7 +506,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_read_2_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_read_2_status_exec_i ();
+    ~info_read_2_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -562,7 +562,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_get_2_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_get_2_status_exec_i ();
+    ~info_get_2_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -618,7 +618,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_2_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_2_data_listener_exec_i ();
+    ~info_state_2_data_listener_exec_i () override;
 
     /** @name Operations from ::ShapeTypeInterface::CCM_StateListener */
     //@{
@@ -684,7 +684,7 @@ namespace subscriber_comp_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::info_state_2_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_state_2_status_exec_i ();
+    ~info_state_2_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -736,7 +736,7 @@ namespace subscriber_comp_Impl
     subscriber_comp_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : subscriber_comp_Impl::subscriber_comp_exec_i[ctor]
     /// Destructor
-    virtual ~subscriber_comp_exec_i ();
+    ~subscriber_comp_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/minimal_latency/components/receiver/latency_receiver_exec.h
+++ b/connectors/dds4ccm/tests/minimal_latency/components/receiver/latency_receiver_exec.h
@@ -51,7 +51,7 @@ namespace Test_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Receiver_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::Test::LatencyDataConnector::CCM_Listener */
     //@{
@@ -107,7 +107,7 @@ namespace Test_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Receiver_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -159,7 +159,7 @@ namespace Test_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.h
+++ b/connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.h
@@ -51,7 +51,7 @@ namespace Test_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Sender_Impl::info_recv_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_recv_data_listener_exec_i ();
+    ~info_recv_data_listener_exec_i () override;
 
     /** @name Operations from ::Test::LatencyDataConnector::CCM_Listener */
     //@{
@@ -107,7 +107,7 @@ namespace Test_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Sender_Impl::info_recv_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_recv_status_exec_i ();
+    ~info_recv_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -164,7 +164,7 @@ namespace Test_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Sender_Impl::connector_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_exec_i ();
+    ~connector_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -237,7 +237,7 @@ namespace Test_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Test_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/examples/apc/apc_sync_default/components/receiver/hello_receiver_exec.h
+++ b/examples/apc/apc_sync_default/components/receiver/hello_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_foo_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_foo_exec_i ();
+    ~do_my_foo_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_MyFoo */
     //@{
@@ -120,7 +120,7 @@ namespace Hello_Receiver_Impl
   Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/examples/apc/apc_sync_default/components/sender/hello_sender_exec.h
+++ b/examples/apc/apc_sync_default/components/sender/hello_sender_exec.h
@@ -55,7 +55,7 @@ namespace Hello_Sender_Impl
   Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/examples/apc/apc_sync_extended/components/receiver/hello_receiver_exec.h
+++ b/examples/apc/apc_sync_extended/components/receiver/hello_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_foo_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_foo_exec_i ();
+    ~do_my_foo_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_MyFoo */
     //@{
@@ -120,7 +120,7 @@ namespace Hello_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/examples/apc/apc_sync_extended/components/sender/hello_sender_exec.h
+++ b/examples/apc/apc_sync_extended/components/sender/hello_sender_exec.h
@@ -55,7 +55,7 @@ namespace Hello_Sender_Impl
   Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/connector.erb
+++ b/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/connector.erb
@@ -21,7 +21,7 @@ namespace <%= executor_cxx_namespace %>
     /// Constructor
     <%= lem_name %>_conn_i () = default;
     /// Destructor
-    virtual ~<%= lem_name %>_conn_i () = default;
+    ~<%= lem_name %>_conn_i () override = default;
 % if all_ports.size > 0
 
     /** @name Component port operations. */

--- a/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/facet_exec.erb
+++ b/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/facet_exec.erb
@@ -11,7 +11,7 @@ public:
      IDL::traits< <%= component.scoped_ccm_name %>_Context>::ref_type context);
 
   /// Destructor
-  virtual ~<%= lem_name %>_exec_i () = default;
+  ~<%= lem_name %>_exec_i () override = default;
 
 %if interface_type.all_operations.size > 0
   /** @name Operations from  <%= interface_type.scoped_ccm_name %> */

--- a/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/reply_handler.erb
+++ b/ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/reply_handler.erb
@@ -14,7 +14,7 @@ public:
     IDL::traits< ::PortableServer::POA>::ref_type poa);
 
   /// Destructor
-  virtual ~<%= interface_type.ami4ccm_reply_handler %> () = default;
+  ~<%= interface_type.ami4ccm_reply_handler %> () override = default;
 % if interface_type.all_operations.size > 0
 
   /// @name Operations from <%= interface_type.ami4ccm_ReplyHandler %>

--- a/ridlbe/ccmx11/facets/corba4ccm/templates/comp_exec/hdr/corba/facet_exec.erb
+++ b/ridlbe/ccmx11/facets/corba4ccm/templates/comp_exec/hdr/corba/facet_exec.erb
@@ -8,7 +8,7 @@ public:
 % visit_facet_constructor
 
   /// Destructor
-  virtual ~<%= lem_name %>_exec_i () = default;
+  ~<%= lem_name %>_exec_i () override = default;
 
 %if interface_type.all_operations.size > 0
   /// @name Operations from <%= scoped_cxxname %>

--- a/ridlbe/ccmx11/templates/comp_exec/hdr/component.erb
+++ b/ridlbe/ccmx11/templates/comp_exec/hdr/component.erb
@@ -19,7 +19,7 @@ namespace <%= executor_cxx_namespace %>
   public:
 % visit_component_constructor
     /// Destructor
-    virtual ~<%= lem_name %>_exec_i ();
+    ~<%= lem_name %>_exec_i () override;
 % if all_ports.size > 0
 
     /** @name Component port operations. */

--- a/ridlbe/ccmx11/templates/comp_exec/hdr/facet_exec.erb
+++ b/ridlbe/ccmx11/templates/comp_exec/hdr/facet_exec.erb
@@ -9,7 +9,7 @@ public:
 % visit_facet_constructor
 
   /// Destructor
-  virtual ~<%= lem_name %>_exec_i ();
+  ~<%= lem_name %>_exec_i () override;
 
 %if interface_type.all_operations.size > 0
   /** @name Operations from <%= interface_type.scoped_ccm_name %> */

--- a/ridlbe/ccmx11/templates/svnt/hdr/component.erb
+++ b/ridlbe/ccmx11/templates/svnt/hdr/component.erb
@@ -20,7 +20,7 @@ namespace <%= executor_cxx_namespace %>
     <%= lem_name %>_Context (IDL::traits<CIAOX11::Service_Registry>::ref_type svcreg, std::string ins_name);
 
     /// Destructor
-    virtual ~<%= lem_name %>_Context () = default;
+    ~<%= lem_name %>_Context () override = default;
 
     /// Retrieve the service registry
     IDL::traits<CIAOX11::Service_Registry>::ref_type the_service_registry () override;
@@ -130,7 +130,7 @@ namespace <%= executor_cxx_namespace %>
       IDL::traits<<%= lem_name %>_Context>::ref_type component_context);
 
     /// Destructor
-    virtual ~<%= lem_name %>_ExecutorLocator () = default;
+    ~<%= lem_name %>_ExecutorLocator () override = default;
 
     /**
      * Configure the component

--- a/tests/apc/async-event-combi/components/receiver/sync_event_receiver_exec.h
+++ b/tests/apc/async-event-combi/components/receiver/sync_event_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_foo_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_foo_exec_i ();
+    ~do_my_foo_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_MyFoo */
     //@{
@@ -124,7 +124,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::info_out_data_listener_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_data_listener_exec_i ();
+    ~info_out_data_listener_exec_i () override;
 
     /** @name Operations from ::Hello::ShapeTypeInterface::CCM_Listener */
     //@{
@@ -180,7 +180,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::info_out_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~info_out_status_exec_i ();
+    ~info_out_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_PortStatusListener */
     //@{
@@ -232,7 +232,7 @@ namespace Hello_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/tests/apc/async-event-combi/components/sender/async_event_sender_exec.h
+++ b/tests/apc/async-event-combi/components/sender/async_event_sender_exec.h
@@ -61,7 +61,7 @@ namespace Hello_Sender_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::connector_status_exec_i[ctor]
 
     /// Destructor
-    virtual ~connector_status_exec_i ();
+    ~connector_status_exec_i () override;
 
     /** @name Operations from ::CCM_DDS::CCM_ConnectorStatusListener */
     //@{
@@ -133,7 +133,7 @@ namespace Hello_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/tests/apc/ext-sync-complex/components/receiver/hello_receiver_exec.h
+++ b/tests/apc/ext-sync-complex/components/receiver/hello_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_B_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_B_exec_i ();
+    ~do_my_B_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_B */
     //@{
@@ -99,7 +99,7 @@ namespace Hello_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/tests/apc/ext-sync-explicit/components/receiver/hello_receiver_exec.h
+++ b/tests/apc/ext-sync-explicit/components/receiver/hello_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_B_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_B_exec_i ();
+    ~do_my_B_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_B */
     //@{
@@ -99,7 +99,7 @@ namespace Hello_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/tests/apc/ext-sync-explicit/components/sender/hello_sender_exec.h
+++ b/tests/apc/ext-sync-explicit/components/sender/hello_sender_exec.h
@@ -55,7 +55,7 @@ namespace Hello_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{


### PR DESCRIPTION
    * connectors/dds4ccm/tests/minimal_latency/components/receiver/latency_receiver_exec.h:
    * connectors/dds4ccm/tests/minimal_latency/components/sender/latency_sender_exec.h:
    * ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/connector.erb:
    * ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/facet_exec.erb:
    * ridlbe/ccmx11/facets/ami4ccm/templates/acon/hdr/reply_handler.erb:
    * ridlbe/ccmx11/facets/corba4ccm/templates/comp_exec/hdr/corba/facet_exec.erb:
    * ridlbe/ccmx11/templates/comp_exec/hdr/component.erb:
    * ridlbe/ccmx11/templates/comp_exec/hdr/facet_exec.erb:
    * ridlbe/ccmx11/templates/svnt/hdr/component.erb: