### PR TITLE
Removed all special QoS settings, testing with as much as defaults as…

### DIFF
--- a/connectors/dds4ccm/tests/latency/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/latency/descriptors/USER_QOS_PROFILES.xml
@@ -8,32 +8,6 @@
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="latencydatalibrary">
     <qos_profile name="LatencyDataProfile" is_default_qos="false">
-      <!-- QoS used to configure the data writer created in the example code -->
-      <participant_qos>
-        <receiver_pool>
-          <!-- (payload) 8192 + (est. overhead) 8 + 512 -->
-          <buffer_size>8712</buffer_size>
-        </receiver_pool>
-
-        <transport_builtin>
-          <mask>DDS_TRANSPORTBUILTIN_UDPv4</mask>
-        </transport_builtin>
-
-        <property>
-          <value>
-            <element>
-              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
-              <value>8712</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
-              <value>17424</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
-              <value>8712</value></element>
-          </value>
-        </property>
-      </participant_qos>
-
       <datawriter_qos>
         <reliability>
           <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
@@ -54,22 +28,7 @@
         </resource_limits>
         <protocol>
           <rtps_reliable_writer>
-            <!-- piggyback every sample -->
             <heartbeats_per_max_samples>3</heartbeats_per_max_samples>
-            <max_nack_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_nack_response_delay>
-            <!-- 1 year -->
-            <heartbeat_period>
-              <sec>604800</sec>
-              <nanosec>1000000</nanosec>
-            </heartbeat_period>
-            <!-- 1 ms -->
-            <fast_heartbeat_period>
-              <sec>0</sec>
-              <nanosec>1000000</nanosec>
-            </fast_heartbeat_period>
           </rtps_reliable_writer>
         </protocol>
       </datawriter_qos>
@@ -90,16 +49,7 @@
         </resource_limits>
         <durability>
           <kind>VOLATILE_DURABILITY_QOS</kind>
-          <direct_communication>true</direct_communication>
         </durability>
-        <protocol>
-          <rtps_reliable_reader>
-            <max_heartbeat_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_heartbeat_response_delay>
-          </rtps_reliable_reader>
-        </protocol>
       </datareader_qos>
     </qos_profile>
   </qos_library>

--- a/connectors/dds4ccm/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml
@@ -8,32 +8,6 @@
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="latencydatalibrary">
     <qos_profile name="LatencyDataProfile" is_default_qos="false">
-      <!-- QoS used to configure the data writer created in the example code -->
-      <participant_qos>
-        <receiver_pool>
-          <!-- (payload) 8192 + (est. overhead) 8 + 512 -->
-          <buffer_size>8712</buffer_size>
-        </receiver_pool>
-
-        <transport_builtin>
-          <mask>DDS_TRANSPORTBUILTIN_UDPv4</mask>
-        </transport_builtin>
-
-        <property>
-          <value>
-            <element>
-              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
-              <value>8712</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
-              <value>17424</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
-              <value>8712</value></element>
-          </value>
-        </property>
-      </participant_qos>
-
       <datawriter_qos>
         <reliability>
           <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
@@ -54,22 +28,7 @@
         </resource_limits>
         <protocol>
           <rtps_reliable_writer>
-            <!-- piggyback every sample -->
             <heartbeats_per_max_samples>3</heartbeats_per_max_samples>
-            <max_nack_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_nack_response_delay>
-            <!-- 1 year -->
-            <heartbeat_period>
-              <sec>604800</sec>
-              <nanosec>1000000</nanosec>
-            </heartbeat_period>
-            <!-- 1 ms -->
-            <fast_heartbeat_period>
-              <sec>0</sec>
-              <nanosec>1000000</nanosec>
-            </fast_heartbeat_period>
           </rtps_reliable_writer>
         </protocol>
       </datawriter_qos>
@@ -90,16 +49,7 @@
         </resource_limits>
         <durability>
           <kind>VOLATILE_DURABILITY_QOS</kind>
-          <direct_communication>true</direct_communication>
         </durability>
-        <protocol>
-          <rtps_reliable_reader>
-            <max_heartbeat_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_heartbeat_response_delay>
-          </rtps_reliable_reader>
-        </protocol>
       </datareader_qos>
     </qos_profile>
   </qos_library>

--- a/ddsx11/tests/latency/descriptors/USER_QOS_PROFILES.xml
+++ b/ddsx11/tests/latency/descriptors/USER_QOS_PROFILES.xml
@@ -8,32 +8,6 @@
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="latencydatalibrary">
     <qos_profile name="LatencyDataProfile" is_default_qos="false">
-      <!-- QoS used to configure the data writer created in the example code -->
-      <participant_qos>
-        <receiver_pool>
-          <!-- (payload) 8192 + (est. overhead) 8 + 512 -->
-          <buffer_size>8712</buffer_size>
-        </receiver_pool>
-
-        <transport_builtin>
-          <mask>DDS_TRANSPORTBUILTIN_UDPv4</mask>
-        </transport_builtin>
-
-        <property>
-          <value>
-            <element>
-              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
-              <value>8712</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
-              <value>17424</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
-              <value>8712</value></element>
-          </value>
-        </property>
-      </participant_qos>
-
       <datawriter_qos>
         <reliability>
           <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
@@ -54,22 +28,7 @@
         </resource_limits>
         <protocol>
           <rtps_reliable_writer>
-            <!-- piggyback every sample -->
             <heartbeats_per_max_samples>3</heartbeats_per_max_samples>
-            <max_nack_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_nack_response_delay>
-            <!-- 1 year -->
-            <heartbeat_period>
-              <sec>604800</sec>
-              <nanosec>1000000</nanosec>
-            </heartbeat_period>
-            <!-- 1 ms -->
-            <fast_heartbeat_period>
-              <sec>0</sec>
-              <nanosec>1000000</nanosec>
-            </fast_heartbeat_period>
           </rtps_reliable_writer>
         </protocol>
       </datawriter_qos>
@@ -90,16 +49,7 @@
         </resource_limits>
         <durability>
           <kind>VOLATILE_DURABILITY_QOS</kind>
-          <direct_communication>true</direct_communication>
         </durability>
-        <protocol>
-          <rtps_reliable_reader>
-            <max_heartbeat_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_heartbeat_response_delay>
-          </rtps_reliable_reader>
-        </protocol>
       </datareader_qos>
     </qos_profile>
   </qos_library>

--- a/ddsx11/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml
+++ b/ddsx11/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml
@@ -8,32 +8,6 @@
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="latencydatalibrary">
     <qos_profile name="LatencyDataProfile" is_default_qos="false">
-      <!-- QoS used to configure the data writer created in the example code -->
-      <participant_qos>
-        <receiver_pool>
-          <!-- (payload) 8192 + (est. overhead) 8 + 512 -->
-          <buffer_size>8712</buffer_size>
-        </receiver_pool>
-
-        <transport_builtin>
-          <mask>DDS_TRANSPORTBUILTIN_UDPv4</mask>
-        </transport_builtin>
-
-        <property>
-          <value>
-            <element>
-              <name>dds.transport.UDPv4.builtin.parent.message_size_max</name>
-              <value>8712</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.recv_socket_buffer_size</name>
-              <value>17424</value></element>
-            <element>
-              <name>dds.transport.UDPv4.builtin.send_socket_buffer_size</name>
-              <value>8712</value></element>
-          </value>
-        </property>
-      </participant_qos>
-
       <datawriter_qos>
         <reliability>
           <kind>BEST_EFFORT_RELIABILITY_QOS</kind>
@@ -54,22 +28,7 @@
         </resource_limits>
         <protocol>
           <rtps_reliable_writer>
-            <!-- piggyback every sample -->
             <heartbeats_per_max_samples>3</heartbeats_per_max_samples>
-            <max_nack_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_nack_response_delay>
-            <!-- 1 year -->
-            <heartbeat_period>
-              <sec>604800</sec>
-              <nanosec>1000000</nanosec>
-            </heartbeat_period>
-            <!-- 1 ms -->
-            <fast_heartbeat_period>
-              <sec>0</sec>
-              <nanosec>1000000</nanosec>
-            </fast_heartbeat_period>
           </rtps_reliable_writer>
         </protocol>
       </datawriter_qos>
@@ -90,16 +49,7 @@
         </resource_limits>
         <durability>
           <kind>VOLATILE_DURABILITY_QOS</kind>
-          <direct_communication>true</direct_communication>
         </durability>
-        <protocol>
-          <rtps_reliable_reader>
-            <max_heartbeat_response_delay>
-              <sec>0</sec>
-              <nanosec>0</nanosec>
-            </max_heartbeat_response_delay>
-          </rtps_reliable_reader>
-        </protocol>
       </datareader_qos>
     </qos_profile>
   </qos_library>


### PR DESCRIPTION
… we can so that we can compare DDS vendors

    * connectors/dds4ccm/tests/latency/descriptors/USER_QOS_PROFILES.xml:
    * connectors/dds4ccm/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml:
    * ddsx11/tests/latency/descriptors/USER_QOS_PROFILES.xml:
    * ddsx11/tests/minimal_latency/descriptors/USER_QOS_PROFILES.xml: