### PR TITLE
Add DDSX11 error handler which we pass to OpenDDS so that we can log …

### DIFF
--- a/connectors/dds4ccm/examples/shapes_asm/shapes_receiver_comp/src/shapes_receiver_comp_exec.h
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_receiver_comp/src/shapes_receiver_comp_exec.h
@@ -42,7 +42,6 @@ namespace Shapes_Receiver_comp_Impl
     : public IDL::traits< ::ShapeTypeInterface::CCM_Listener>::base_type
   {
   public:
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Shapes_Receiver_comp_Impl::info_out_data_listener_exec_i[ctor]
     /// Constructor
     /// @param[in] context Component context
@@ -98,7 +97,6 @@ namespace Shapes_Receiver_comp_Impl
     : public IDL::traits< ::CCM_DDS::CCM_PortStatusListener>::base_type
   {
   public:
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Shapes_Receiver_comp_Impl::info_out_status_exec_i[ctor]
     /// Constructor
     /// @param[in] context Component context

--- a/connectors/dds4ccm/examples/shapes_asm/shapes_sender_comp/src/shapes_sender_comp_exec.h
+++ b/connectors/dds4ccm/examples/shapes_asm/shapes_sender_comp/src/shapes_sender_comp_exec.h
@@ -42,7 +42,6 @@ namespace Shapes_Sender_comp_Impl
     : public IDL::traits< ::Shapes::CCM_Control_obj>::base_type
   {
   public:
-
     //@@{__RIDL_REGEN_MARKER__} - BEGIN : Shapes_Sender_comp_Impl::control_exec_i[ctor]
     /// Constructor
     /// @param[in] context Component context

--- a/ddsx11/vendors/opendds/MPC/config/ddsx11_vendor_impl.mpb
+++ b/ddsx11/vendors/opendds/MPC/config/ddsx11_vendor_impl.mpb
@@ -20,6 +20,7 @@ project : ddsx11_opendds_flags, \
     ../vendors/opendds/dds/opendds_subscriber.h
     ../vendors/opendds/dds/opendds_typedefs.h
     ../vendors/opendds/dds/dds_listener_guard_t.h
+    ../vendors/opendds/dds/opendds_xml_error_handler.h
   }
 
   Source_Files {
@@ -28,9 +29,11 @@ project : ddsx11_opendds_flags, \
     ../vendors/opendds/dds/opendds_publisher.cpp
     ../vendors/opendds/dds/opendds_specific.cpp
     ../vendors/opendds/dds/opendds_subscriber.cpp
+    ../vendors/opendds/dds/opendds_xml_error_handler.cpp
   }
 
   Template_Files {
     ../vendors/opendds/dds/dds_data_reader_native_entity_t.cpp
+    ../vendors/opendds/dds/dds_data_writer_native_entity_t.cpp
   }
 }

--- a/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.cpp
+++ b/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file    opendds_xml_error_handler.cpp
+ * @author  Johnny Willemsen
+ *
+ * @brief  DDSX11 version  error handler for Xerces
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+
+#include "dds/opendds_xml_error_handler.h"
+#include <xercesc/util/XMLString.hpp>
+#include <xercesc/dom/DOMLocator.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include "ace/XML_Utils/XercesString.h"
+#include "ddsx11/logger/ddsx11_log.h"
+
+namespace DDSX11
+{
+  void DDSX11_XML_Error_Handler::warning(const xercesc::SAXParseException& toCatch)
+  {
+    XML::XStr file(toCatch.getSystemId ());
+    XML::XStr msg (toCatch.getMessage ());
+
+    DDSX11_IMPL_LOG_DEBUG ("Warning: " << file << ':' << toCatch.getLineNumber ()
+                      << ':' << toCatch.getColumnNumber () << " - "
+                      << msg);
+  }
+
+  void DDSX11_XML_Error_Handler::error(const xercesc::SAXParseException& toCatch)
+  {
+    XML::XStr file (toCatch.getSystemId ());
+    XML::XStr msg (toCatch.getMessage ());
+
+    DDSX11_IMPL_LOG_ERROR ("Error: " << file << ':' << toCatch.getLineNumber ()
+                      << ':' << toCatch.getColumnNumber () << " - "
+                      << msg);
+
+    this->errors_ = true;
+  }
+
+  void DDSX11_XML_Error_Handler::fatalError(const xercesc::SAXParseException& toCatch)
+  {
+    XML::XStr file (toCatch.getSystemId ());
+    XML::XStr msg (toCatch.getMessage ());
+
+    DDSX11_IMPL_LOG_PANIC ("Fatal Error: " << file << ':' << toCatch.getLineNumber ()
+                  << ':' << toCatch.getColumnNumber () << " - "
+                  << msg);
+
+    this->errors_ = true;
+  }
+
+#if ACE_VERSION_CODE <= 0x70003
+  void DDSX11_XML_Error_Handler::resetErrors()
+  {
+    this->errors_ = false;
+  }
+
+  bool DDSX11_XML_Error_Handler::getErrors () const
+  {
+    return this->errors_;
+  }
+#endif
+}

--- a/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.h
+++ b/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.h
@@ -23,11 +23,7 @@ namespace DDSX11
     *
     */
   class DDSX11_IMPL_Export DDSX11_XML_Error_Handler final
-#if ACE_VERSION_CODE <= 0x70003
-    : public xercesc::ErrorHandler
-#else
     : public XML::XML_Error_Handler
-#endif
   {
   public:
     DDSX11_XML_Error_Handler () = default;

--- a/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.h
+++ b/ddsx11/vendors/opendds/dds/opendds_xml_error_handler.h
@@ -1,0 +1,54 @@
+/**
+ * @file    opendds_xml_error_handler.h
+ * @author  Johnny Willemsen
+ *
+ * @brief  DDSX11 version  error handler for Xerces
+ *
+ * @copyright Copyright (c) Remedy IT Expertise BV
+ */
+#ifndef DDSX11_XML_ERROR_HANDLER_H
+#define DDSX11_XML_ERROR_HANDLER_H
+
+#pragma once
+
+#include "dds/dds_export.h"
+#include <ace/XML_Utils/XML_Error_Handler.h>
+
+namespace DDSX11
+{
+  /**
+    * @class DDSX11_XML_Error_Hander
+    *
+    * @brief DDSX11 error handler for XERCES
+    *
+    */
+  class DDSX11_IMPL_Export DDSX11_XML_Error_Handler final
+#if ACE_VERSION_CODE <= 0x70003
+    : public xercesc::ErrorHandler
+#else
+    : public XML::XML_Error_Handler
+#endif
+  {
+  public:
+    DDSX11_XML_Error_Handler () = default;
+    ~DDSX11_XML_Error_Handler () override = default;
+
+    void warning(const xercesc::SAXParseException& toCatch) override;
+    void error(const xercesc::SAXParseException& toCatch) override;
+    void fatalError(const xercesc::SAXParseException& toCatch) override;
+#if ACE_VERSION_CODE <= 0x70003
+    void resetErrors() override;
+    bool getErrors () const;
+#endif
+  private :
+    DDSX11_XML_Error_Handler (const DDSX11_XML_Error_Handler&) = delete;
+    DDSX11_XML_Error_Handler& operator= (const DDSX11_XML_Error_Handler&) = delete;
+    DDSX11_XML_Error_Handler (DDSX11_XML_Error_Handler&&) = delete;
+    DDSX11_XML_Error_Handler& operator= (DDSX11_XML_Error_Handler&&) = delete;
+#if ACE_VERSION_CODE <= 0x70003
+    bool errors_ {};
+#endif
+  };
+}
+
+#endif /* DDSX11_XML_ERROR_HANDLER_H */


### PR DESCRIPTION
…any XML parsing errors using the DDSX11 logger. Depends on a OpenDDS extension which should be in 3.19

    * ddsx11/vendors/opendds/dds/opendds_xml_error_handler.cpp:
    * ddsx11/vendors/opendds/dds/opendds_xml_error_handler.h:
      Added.

    * connectors/dds4ccm/examples/shapes_asm/shapes_receiver_comp/src/shapes_receiver_comp_exec.h:
    * connectors/dds4ccm/examples/shapes_asm/shapes_sender_comp/src/shapes_sender_comp_exec.h:
    * ddsx11/vendors/opendds/MPC/config/ddsx11_vendor_impl.mpb:
    * ddsx11/vendors/opendds/dds/opendds_domain_participant_factory.cpp: