### PR TITLE
Support typedef FooSeq for type Foo when using ddsx11/dds4ccm

### DIFF
--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------
 
 feature(ddsx11, ndds) : ndds_ts_defaults {
-  ndds_ts_flags += -enableEscapeChar
+  ndds_ts_flags += -enableEscapeChar -typeSequenceSuffix RTISeq
   Define_Custom(TypeSupport) {
   }
   Define_Custom(DummyTypeSupport) {

--- a/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/templates/udt_traits/ndds/sequence.erb
+++ b/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/templates/udt_traits/ndds/sequence.erb
@@ -3,11 +3,11 @@
 // Unaliased type      : <%= resolved_cxxtype %>
 // Scoped element type : <%= scoped_element_cxxtype %>
 // Aliased DDS type    : ::DDS_Native<%= scoped_cxxtype %>
-% ndds_alias_md5 = (resolved_cxxtype+scoped_element_cxxtype).to_md5
-// NDDS MD5 : <%= ndds_alias_md5 %>
-#if !defined(_ALIAS_<%= ndds_alias_md5 %>_UDT_TRAITS_DECL_)
-#define _ALIAS_<%= ndds_alias_md5 %>_UDT_TRAITS_DECL_
+% ddsx11_alias_md5 = (resolved_cxxtype+scoped_element_cxxtype).to_md5
+// DDSX11 MD5 : <%= ddsx11_alias_md5 %>
+#if !defined(_ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_)
+#define _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_
 
 %visit_template('sequence_impl')
 
-#endif /* _ALIAS_<%= ndds_alias_md5 %>_UDT_TRAITS_DECL_ */
+#endif /* _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_ */

--- a/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/visitorbase.rb
+++ b/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/visitorbase.rb
@@ -23,6 +23,10 @@ module IDL
       def native_scoped_name_prefix
         '::DDS_Native' + (!scoped_enclosure_cxxname.empty? ? '::' : '') + "#{scoped_enclosure_cxxname}::#{cxxname}"
       end
+
+      def native_scoped_seq_cxxtype
+        "#{native_scoped_name_prefix}RTISeq"
+      end
     end # VisitorBase
 
   end # Cxx11

--- a/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/udt_traits/opendds/sequence.erb
+++ b/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/udt_traits/opendds/sequence.erb
@@ -3,7 +3,7 @@
 // Unaliased type : <%= resolved_cxxtype %>
 // Aliased DDS type : <%= native_scoped_cxxtype %>
 % ddsx11_alias_md5_string =  native_scoped_cxxtype+resolved_cxxtype
-% ddsx11_alias_md5 = dddsx11_alias_md5_string.to_md5
+% ddsx11_alias_md5 = ddsx11_alias_md5_string.to_md5
 // DDSX11 MD5 : <%= ddsx11_alias_md5 %>
 #if !defined(_ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_)
 #define _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_

--- a/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/udt_traits/opendds/sequence.erb
+++ b/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/udt_traits/opendds/sequence.erb
@@ -2,12 +2,12 @@
 // generated from <%= ridl_template_path %>
 // Unaliased type : <%= resolved_cxxtype %>
 // Aliased DDS type : <%= native_scoped_cxxtype %>
-% opendds_alias_md5_string =  native_scoped_cxxtype+resolved_cxxtype
-% opendds_alias_md5 = opendds_alias_md5_string.to_md5
-// OpenDDS MD5 : <%= opendds_alias_md5 %>
-#if !defined(_ALIAS_<%= opendds_alias_md5 %>_UDT_TRAITS_DECL_)
-#define _ALIAS_<%= opendds_alias_md5 %>_UDT_TRAITS_DECL_
+% ddsx11_alias_md5_string =  native_scoped_cxxtype+resolved_cxxtype
+% ddsx11_alias_md5 = dddsx11_alias_md5_string.to_md5
+// DDSX11 MD5 : <%= ddsx11_alias_md5 %>
+#if !defined(_ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_)
+#define _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_
 
 %visit_template('sequence_impl')
 
-#endif /* _ALIAS_<%= opendds_alias_md5 %>_UDT_TRAITS_DECL_ */
+#endif /* _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_ */

--- a/ridlbe/ccmx11/facets/dds/config.rb
+++ b/ridlbe/ccmx11/facets/dds/config.rb
@@ -86,7 +86,6 @@ module IDL
             options.gen_idl_for_dds = true
             options.gen_idl_for_typed_entities = true
             options.gen_impl_for_type_support = true
-            options.gen_typedef_sequence_dds_type = true
           end
 
           IDL::CCMX11::DDSX11.prepare_dds_options(options, idl_ext)

--- a/ridlbe/ccmx11/facets/dds/templates/idl/typed_entities/entities.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/typed_entities/entities.erb
@@ -2,8 +2,8 @@
 // generated from <%= ridl_template_path %>
 % if typedef_sequence_dds_type_needed?
 <%= typedef_sequence_dds_type %>
-% end
 
+% end
 local interface <%= name %>DataWriter : ::DDS::DataWriter
 {
   DDS::InstanceHandle_t register_instance(

--- a/ridlbe/ccmx11/facets/dds/templates/typesupport/src/toplevel_seq.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/typesupport/src/toplevel_seq.erb
@@ -1,7 +1,14 @@
 %if has_toplevel_annotation?
 
+% unaliased_type = 'std::vector< '+resolved_cxxtype+'>'
+// Unaliased type      : <%= unaliased_type %>
+// Scoped element type : <%= scoped_cxxtype %>
+% ddsx11_alias_md5 = (unaliased_type+scoped_cxxtype).to_md5
+// DDSX11 MD5 : <%= ddsx11_alias_md5 %>
 namespace DDSX11
 {
+#if !defined(_ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_)
+#define _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_
   // generated from <%= ridl_template_path %>
   /// Conversion of <%= scoped_seq_cxxtype %> to DDS
   template<>
@@ -20,6 +27,7 @@ namespace DDSX11
   {
     return DDSX11::sequence_from_dds(to, from);
   }
+#endif /* _ALIAS_<%= ddsx11_alias_md5 %>_UDT_TRAITS_DECL_ */
 
   template<>
   struct traits< <%= scoped_seq_cxxtype %>>
@@ -30,4 +38,5 @@ namespace DDSX11
   {
   };
 } /* DDSX11 */
+
 %end

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -40,12 +40,18 @@ module IDL
       end
 
       def typedef_sequence_dds_type_needed?
-        params[:gen_typedef_sequence_dds_type]
+        # Only generate a implied unbounded sequence typedef when there is not in the enclosing scope a typedef of our type
+        # with a Seq postfix already
+        @node.enclosure.select_members { |m| m.is_a?(IDL::AST::Typedef) && m.idltype.is_a?(IDL::Type::Sequence) && (m.idltype.basetype.resolved_type.is_a?(IDL::Type::Struct) || m.idltype.basetype.resolved_type.is_a?(IDL::Type::Union)) && m.idltype.basetype.resolved_type.resolved_node == @node && m.unescaped_name == sequence_dds_type && m.idltype.size.nil?}.empty?
+      end
+
+      def sequence_dds_type
+        "#{name}Seq"
       end
 
       def typedef_sequence_dds_type
         # No cxxname since we're writing to IDL
-        return "typedef sequence<#{unescaped_name}> #{name}Seq;"
+        return "typedef sequence<#{unescaped_name}> #{sequence_dds_type};"
       end
 
       def strip_global_scope(typename)


### PR DESCRIPTION
When the user adds a typedef FooSeq for type Foo to his IDL we will suppress the generation of the implied DDS sequence in ddsx11 and the hidden DDS vendor FooSeq is given a different internal name, FooRTISeq when using RTI Connext DDS. A same change is pending for OpenDDS, waiting on the necessary OpenDDS support