### PR TITLE
Include all default sequences which are in the tao core to prevent po…

### DIFF
--- a/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/idl/dds/opendds/pre.erb
+++ b/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/idl/dds/opendds/pre.erb
@@ -10,6 +10,18 @@
 
 // The includes below are needed to deal with compilers that
 // have ACE_HAS_EXPLICIT_TEMPLATE_INSTANTIATION_EXPORT
-#include "tao/StringSeq.pidl"
-#include "tao/LongSeq.pidl"
 #include "tao/BooleanSeq.pidl"
+#include "tao/CharSeq.pidl"
+#include "tao/DoubleSeq.pidl"
+#include "tao/FloatSeq.pidl"
+#include "tao/LongDoubleSeq.pidl"
+#include "tao/LongLongSeq.pidl"
+#include "tao/LongSeq.pidl"
+#include "tao/OctetSeq.pidl"
+#include "tao/ShortSeq.pidl"
+#include "tao/StringSeq.pidl"
+#include "tao/ULongLongSeq.pidl"
+#include "tao/ULongSeq.pidl"
+#include "tao/UShortSeq.pidl"
+#include "tao/WCharSeq.pidl"
+#include "tao/WStringSeq.pidl"


### PR DESCRIPTION
…ssible errors with explicit template instantiation import/rxport

    * ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/idl/dds/opendds/pre.erb: