### PR TITLE
Do not use parentheses for method calls with no arguments

### DIFF
--- a/brix/ciaox11/cmds/create_proj.rb
+++ b/brix/ciaox11/cmds/create_proj.rb
@@ -44,7 +44,7 @@ module BRIX11
       def run(argv)
         argv ||= []
         # Load recipe_files, make recipes,
-        project = AxciomaPC::Project.load_project()
+        project = AxciomaPC::Project.load_project
 
         if options[:verbose] > 5
           project.dump
@@ -56,7 +56,7 @@ module BRIX11
         end
 
         #make the  mpcfiles
-        project.prepare()
+        project.prepare
 
         if options[:verbose] > 5
           project.dump

--- a/ridlbe/ccmx11/facets/ami4ccm/writers/amiconnector.rb
+++ b/ridlbe/ccmx11/facets/ami4ccm/writers/amiconnector.rb
@@ -56,7 +56,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiConnectorConnIDLWriter#enter_module')
         printiln('module ' + node.cxxname)
         printiln('{')
@@ -65,7 +65,7 @@ module IDL
 
       def leave_module(node)
         dec_nest
-        println()
+        println
         printiln("}; // module #{node.cxxname}")
         super
       end
@@ -115,7 +115,7 @@ module IDL
 
       def enter_module(node)
         super
-        println()
+        println
         printiln('// generated from AmiConnectorIDLWriter#enter_module')
         printiln('module ' + node.cxxname)
         printiln('{')
@@ -124,7 +124,7 @@ module IDL
 
       def leave_module(node)
         dec_nest
-        println()
+        println
         printiln("}; // module #{node.cxxname}")
         super
       end

--- a/ridlbe/ccmx11/facets/dds/writers/ddsidl.rb
+++ b/ridlbe/ccmx11/facets/dds/writers/ddsidl.rb
@@ -117,7 +117,7 @@ module IDL
         def mark_namespace_end(node)
           if @current_module >= 0 && @module_stack[@current_module] == node
             dec_nest
-            println()
+            println
             printiln("}; // module #{node.unescaped_name}")
             @current_module -= 1
           end
@@ -126,7 +126,7 @@ module IDL
 
         def check_dds_native_namespace
           unless @dds_native_module
-            println()
+            println
             printiln('module DDS_Native')
             printiln('{')
             inc_nest
@@ -137,7 +137,7 @@ module IDL
         def check_dds_native_namespace_end
           if @dds_native_module
             dec_nest
-            println()
+            println
             printiln('}; // module DDS_Native')
             @dds_native_module = false
           end

--- a/ridlbe/ccmx11/writers/localexecutormapping.rb
+++ b/ridlbe/ccmx11/writers/localexecutormapping.rb
@@ -167,7 +167,7 @@ module IDL
       def enter_module(node)
         super
         if module_needs_lem_code?(node)
-          println()
+          println
           printiln('// generated from LemExecutorIDLWriter#enter_module')
           printiln('module ' + node.unescaped_name)
           printiln('{')
@@ -178,7 +178,7 @@ module IDL
       def leave_module(node)
         if module_needs_lem_code?(node)
           dec_nest
-          println()
+          println
           printiln("}; // module #{node.unescaped_name}")
           super
         end

--- a/scripts/converting/convert_plan.rb
+++ b/scripts/converting/convert_plan.rb
@@ -131,7 +131,7 @@ module CIAOX11_Plan_Converter
         #nothing shouldn't happen
       end
     end
-    file_tmp.close!()
+    file_tmp.close!
   end
 
   def self.check_input_file_name (filename)


### PR DESCRIPTION
    * brix/ciaox11/cmds/create_proj.rb:
    * ridlbe/ccmx11/facets/ami4ccm/writers/amiconnector.rb:
    * ridlbe/ccmx11/facets/dds/writers/ddsidl.rb:
    * ridlbe/ccmx11/writers/localexecutormapping.rb:
    * scripts/converting/convert_plan.rb: