### PR TITLE
Add space in debug message

### DIFF
--- a/examples/apc/apc_sync_extended/components/receiver/hello_receiver_exec.cpp
+++ b/examples/apc/apc_sync_extended/components/receiver/hello_receiver_exec.cpp
@@ -195,7 +195,7 @@ namespace Hello_Receiver_Impl
          ACE::INet::URLStream urlin = http_url.open (rh);
          if (urlin)
          {
-            CIAOX11_TEST_INFO << "opened URL" << http_url.to_string () << std::endl;
+            CIAOX11_TEST_INFO << "opened URL " << http_url.to_string () << std::endl;
 
             ACE::IOS::CString_OStream sos;
             sos << urlin->rdbuf ();

--- a/tests/apc/extra-libs-comp/components/sender/hello_sender_exec.cpp
+++ b/tests/apc/extra-libs-comp/components/sender/hello_sender_exec.cpp
@@ -62,7 +62,7 @@ namespace Hello_Sender_Impl
        ACE::INet::URLStream urlin = http_url.open (rh);
        if (urlin)
        {
-          CIAOX11_TEST_INFO << "opened URL" << http_url.to_string () << std::endl;
+          CIAOX11_TEST_INFO << "opened URL " << http_url.to_string () << std::endl;
 
           ACE::IOS::CString_OStream sos;
           sos << urlin->rdbuf ();

--- a/tests/apc/extra-libs-project/components/control_comp/hello_sender_exec.cpp
+++ b/tests/apc/extra-libs-project/components/control_comp/hello_sender_exec.cpp
@@ -62,7 +62,7 @@ namespace Hello_Sender_Impl
        ACE::INet::URLStream urlin = http_url.open (rh);
        if (urlin)
        {
-          CIAOX11_TEST_INFO << "opened URL" << http_url.to_string () << std::endl;
+          CIAOX11_TEST_INFO << "opened URL " << http_url.to_string () << std::endl;
 
           ACE::IOS::CString_OStream sos;
           sos << urlin->rdbuf ();

--- a/tests/apc/extra-libs-project/components/sender/hello_sender_exec.cpp
+++ b/tests/apc/extra-libs-project/components/sender/hello_sender_exec.cpp
@@ -62,7 +62,7 @@ namespace Hello_Sender_Impl
        ACE::INet::URLStream urlin = http_url.open (rh);
        if (urlin)
        {
-          CIAOX11_TEST_INFO << "opened URL" << http_url.to_string () << std::endl;
+          CIAOX11_TEST_INFO << "opened URL " << http_url.to_string () << std::endl;
 
           ACE::IOS::CString_OStream sos;
           sos << urlin->rdbuf ();


### PR DESCRIPTION
    * examples/apc/apc_sync_extended/components/receiver/hello_receiver_exec.cpp:
    * tests/apc/extra-libs-comp/components/sender/hello_sender_exec.cpp:
    * tests/apc/extra-libs-project/components/control_comp/hello_sender_exec.cpp:
    * tests/apc/extra-libs-project/components/sender/hello_sender_exec.cpp: