### PR TITLE
Use override for destructors, made some default

### DIFF
--- a/exf/connectors/ami4ccm/tests/exf/hello_simple/receiver/hello_receiver_exec.h
+++ b/exf/connectors/ami4ccm/tests/exf/hello_simple/receiver/hello_receiver_exec.h
@@ -48,7 +48,7 @@ namespace Hello_Receiver_Impl
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::do_my_foo_exec_i[ctor]
 
     /// Destructor
-    virtual ~do_my_foo_exec_i ();
+    ~do_my_foo_exec_i () override;
 
     /** @name Operations from ::Hello::CCM_MyFoo */
     //@{
@@ -123,7 +123,7 @@ namespace Hello_Receiver_Impl
     Receiver_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Receiver_Impl::Receiver_exec_i[ctor]
     /// Destructor
-    virtual ~Receiver_exec_i ();
+    ~Receiver_exec_i () override;
 
     /** @name Component port operations. */
     //@{

--- a/exf/connectors/ami4ccm/tests/exf/hello_simple/sender/hello_sender_exec.h
+++ b/exf/connectors/ami4ccm/tests/exf/hello_simple/sender/hello_sender_exec.h
@@ -79,7 +79,7 @@ namespace Hello_Sender_Impl
     Sender_exec_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::Sender_exec_i[ctor]
     /// Destructor
-    virtual ~Sender_exec_i ();
+    ~Sender_exec_i () override;
 
     /** @name Component port operations. */
     //@{
@@ -154,7 +154,7 @@ namespace Hello_Sender_Impl
     AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::AMI4CCM_MyFooReplyHandler_run_my_foo_i[ctor]
 
-    virtual ~AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
+    ~AMI4CCM_MyFooReplyHandler_run_my_foo_i () override;
 
     void
     foo (

--- a/exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_executors.h
+++ b/exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_executors.h
@@ -42,7 +42,7 @@ namespace CIAOX11
           , listener_ (std::move (lsn))
           , event_id_ (std::move (evtid))
         {}
-        virtual ~DDSExecutorBase () = default;
+        ~DDSExecutorBase () override = default;
 
         void execute () noexcept(true) override
         {
@@ -105,7 +105,7 @@ namespace CIAOX11
           , entity_ (entity)
           , status_kind_ (status_kind)
         {}
-        virtual ~UnexpectedStatusExecutor () = default;
+        ~UnexpectedStatusExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -144,7 +144,7 @@ namespace CIAOX11
           , dr_ (dr)
           , status_ (status)
         {}
-        virtual ~RequestedIncompatibleQosExecutor () = default;
+        ~RequestedIncompatibleQosExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -183,7 +183,7 @@ namespace CIAOX11
           , dr_ (dr)
           , status_ (status)
         {}
-        virtual ~SampleRejectedExecutor () = default;
+        ~SampleRejectedExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -222,7 +222,7 @@ namespace CIAOX11
           , tp_ (tp)
           , status_ (status)
         {}
-        virtual ~InconsistentTopicExecutor () = default;
+        ~InconsistentTopicExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -261,7 +261,7 @@ namespace CIAOX11
           , dw_ (dw)
           , status_ (status)
         {}
-        virtual ~OfferedDeadlineMissedExecutor () = default;
+        ~OfferedDeadlineMissedExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -300,7 +300,7 @@ namespace CIAOX11
           , dw_ (dw)
           , status_ (status)
         {}
-        virtual ~OfferedIncompatibleQoSExecutor () = default;
+        ~OfferedIncompatibleQoSExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::ConnectorStatusListener>::ref_type listener)
@@ -339,7 +339,7 @@ namespace CIAOX11
           , dr_ (dr)
           , status_ (status)
         {}
-        virtual ~RequestedDeadlineMissedExecutor () = default;
+        ~RequestedDeadlineMissedExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::PortStatusListener>::ref_type listener)
@@ -378,7 +378,7 @@ namespace CIAOX11
           , dr_ (dr)
           , status_ (status)
         {}
-        virtual ~SampleLostExecutor () = default;
+        ~SampleLostExecutor () override = default;
 
       protected:
         virtual void execute_i (IDL::traits<CCM_DDS::PortStatusListener>::ref_type listener)
@@ -418,7 +418,7 @@ namespace CIAOX11
           , drl_ (std::move(drl))
           , dr_ (std::move(dr))
         {}
-        virtual ~DataReaderExecutor_T () = default;
+        ~DataReaderExecutor_T () override = default;
 
       protected:
         virtual void execute_i (typename IDL::traits<DATA_LISTENER>::ref_type listener)

--- a/exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_strategies_t.h
+++ b/exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_strategies_t.h
@@ -436,7 +436,7 @@ namespace CIAOX11
         , sample_lost_priority_ (pses.sample_lost_priority_)
         {}
       public:
-        virtual ~PortStatusEventStrategyBase () = default;
+        ~PortStatusEventStrategyBase () override = default;
 
         // on_requested_deadline_missed
         void
@@ -621,7 +621,7 @@ namespace CIAOX11
           : DataEventStrategyBase_T<
               typename CCM_TYPE::push_consumer_traits::data_listener_type> (pces)
         {}
-        virtual ~PushConsumerEventStrategy_T () = default;
+        ~PushConsumerEventStrategy_T () override = default;
       };
 
       template <typename CCM_TYPE>
@@ -638,7 +638,7 @@ namespace CIAOX11
         PullConsumerEventStrategy_T (const PullConsumerEventStrategy_T& pces)
           : PortStatusEventStrategyBase (pces)
         {}
-        virtual ~PullConsumerEventStrategy_T () = default;
+        ~PullConsumerEventStrategy_T () override = default;
       };
 
       template <typename CCM_TYPE>
@@ -655,7 +655,7 @@ namespace CIAOX11
         PassiveObserverEventStrategy_T (const PassiveObserverEventStrategy_T& poes)
           : PortStatusEventStrategyBase (poes)
         {}
-        virtual ~PassiveObserverEventStrategy_T () = default;
+        ~PassiveObserverEventStrategy_T () override = default;
       };
 
       template <typename CCM_TYPE>
@@ -672,7 +672,7 @@ namespace CIAOX11
         PullObserverEventStrategy_T (const PullObserverEventStrategy_T& poes)
           : PortStatusEventStrategyBase (poes)
         {}
-        virtual ~PullObserverEventStrategy_T () = default;
+        ~PullObserverEventStrategy_T () override = default;
       };
 
       template <typename CCM_TYPE>
@@ -694,7 +694,7 @@ namespace CIAOX11
           : DataEventStrategyBase_T<
               typename CCM_TYPE::push_observer_traits::data_listener_type> (poes)
         {}
-        virtual ~PushObserverEventStrategy_T () = default;
+        ~PushObserverEventStrategy_T () override = default;
       };
 
       template <typename CCM_TYPE>
@@ -716,7 +716,7 @@ namespace CIAOX11
           : DataEventStrategyBase_T<
               typename CCM_TYPE::push_state_observer_traits::data_listener_type> (psoes)
         {}
-        virtual ~PushStateObserverEventStrategy_T () = default;
+        ~PushStateObserverEventStrategy_T () override = default;
       };
 
     } /* namespace ExF */

--- a/exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_executors.h
+++ b/exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_executors.h
@@ -40,7 +40,7 @@ namespace CIAOX11
           , dh_ (dh.weak_reference ())
           , dl_ (std::move (dl))
         {}
-        virtual ~PSDDDataListenerExecutor () = default;
+        ~PSDDDataListenerExecutor () override = default;
 
         void execute () noexcept(true) override
         {

--- a/exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_strategies_t.h
+++ b/exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_strategies_t.h
@@ -112,7 +112,7 @@ namespace CIAOX11
           , data_available_priority_ (dpces.data_available_priority_)
         {}
 
-        virtual ~PushConsumerEventStrategy_T () = default;
+        ~PushConsumerEventStrategy_T () override = default;
 
         PushConsumerEventStrategy_T& operator =(
             const PushConsumerEventStrategy_T& dpces)

--- a/exf/deployment/amh/ciaox11_exf_exec_base.h
+++ b/exf/deployment/amh/ciaox11_exf_exec_base.h
@@ -26,7 +26,7 @@ namespace CIAOX11
       public:
         AMH_Executor (ExF::Priority prio, ExF::Deadline dltm)
           : Executor (prio, dltm) {}
-        virtual ~AMH_Executor () = default;
+        ~AMH_Executor () override = default;
 
         void execute () noexcept(true) override;
 

--- a/exf/deployment/core/ciaox11_monitor_svc.h
+++ b/exf/deployment/core/ciaox11_monitor_svc.h
@@ -27,7 +27,7 @@ namespace CIAOX11
     {
     public:
       /// The destructor
-      virtual ~DeadlineMonitorSvc ();
+      ~DeadlineMonitorSvc () override;
 
       /**
        * Create and return the reference to a monitor instance.

--- a/exf/deployment/core/ciaox11_schedule.h
+++ b/exf/deployment/core/ciaox11_schedule.h
@@ -218,7 +218,7 @@ namespace CIAOX11
       : public ::CORBA::LocalObject
     {
     public:
-      virtual ~SchedulingLane ();
+      ~SchedulingLane () override ;
 
       virtual ExF::Count trafic_count () = 0;
 

--- a/exf/deployment/core/ciaox11_scheduler_svc.h
+++ b/exf/deployment/core/ciaox11_scheduler_svc.h
@@ -28,7 +28,7 @@ namespace CIAOX11
     {
     public:
       /// The destructor
-      virtual ~SchedulerSvc ();
+      ~SchedulerSvc () override;
 
       /**
        * Create and return the reference to a monitor instance.

--- a/exf/deployment/handlers/ciaox11_exf_component_handler.h
+++ b/exf/deployment/handlers/ciaox11_exf_component_handler.h
@@ -36,7 +36,7 @@ namespace CIAOX11
         : CIAOX11::Component_Handler (std::move (ch)) {}
 
       /// Destructor
-      virtual ~Component_Handler ();
+      ~Component_Handler () override;
 
       void install_instance (const ::Deployment::DeploymentPlan & plan,
                              uint32_t instanceRef,

--- a/exf/deployment/handlers/ciaox11_exf_container.cpp
+++ b/exf/deployment/handlers/ciaox11_exf_container.cpp
@@ -42,7 +42,7 @@ namespace CIAOX11
        : sem_ (sem) {}
       LifecycleExecutor (std::shared_ptr<LifecycleSemaphore> sem, ExF::Priority prio, ExF::Deadline dltm)
        : Executor (prio, dltm), sem_ (sem) {}
-      virtual ~LifecycleExecutor () {}
+      ~LifecycleExecutor () override = default;
 
       virtual void execute () noexcept(true);
 

--- a/exf/deployment/handlers/ciaox11_exf_container.h
+++ b/exf/deployment/handlers/ciaox11_exf_container.h
@@ -27,7 +27,7 @@ namespace CIAOX11
       Container (std::string name,
                  IDL::traits<CORBA::ORB>::ref_type orb,
                  ExF::Scheduler::ref_type sched);
-      virtual ~Container ();
+      ~Container () override;
 
       void fini () override;
 

--- a/exf/deployment/handlers/ciaox11_exf_container_handler.h
+++ b/exf/deployment/handlers/ciaox11_exf_container_handler.h
@@ -28,7 +28,7 @@ namespace CIAOX11
       Container_Handler () = default;
 
       // Destructor
-      virtual ~Container_Handler ();
+      ~Container_Handler () override;
 
       void install_instance (const ::Deployment::DeploymentPlan & plan,
                              uint32_t instanceRef,

--- a/exf/deployment/logger/log.h
+++ b/exf/deployment/logger/log.h
@@ -42,7 +42,7 @@ namespace CIAOX11
     {
     public:
       CIAOX11_EXF_Log_Msg();
-      virtual ~CIAOX11_EXF_Log_Msg();
+       ~CIAOX11_EXF_Log_Msg() override;
 
       static CIAOX11_EXF_Log_Msg* getInstance();
 

--- a/exf/deployment/scheduler/ciaox11_exf_dispatcher.h
+++ b/exf/deployment/scheduler/ciaox11_exf_dispatcher.h
@@ -131,7 +131,7 @@ namespace CIAOX11
                       this->executor_->deadline ().deadline_type_;
             }
           }
-          virtual ~DispatchTask () {}
+          ~DispatchTask () override = default;
 
           virtual const ExF::Deadline& deadline () const noexcept(true);
 

--- a/exf/deployment/scheduler/ciaox11_exf_scheduler_i.cpp
+++ b/exf/deployment/scheduler/ciaox11_exf_scheduler_i.cpp
@@ -23,7 +23,7 @@ namespace CIAOX11
       public:
         SchedulingLane (ExF::Impl::Dispatcher::gate_ref gate)
           : gate_ (gate) {}
-        virtual ~SchedulingLane ();
+        ~SchedulingLane () override;
 
         virtual ExF::Count trafic_count ()
         { return this->gate_->queued_count (); }

--- a/exf/deployment/scheduler/ciaox11_exf_scheduler_i.h
+++ b/exf/deployment/scheduler/ciaox11_exf_scheduler_i.h
@@ -31,7 +31,7 @@ namespace CIAOX11
       {
       public:
         Scheduler (const Components::ConfigValues& cfg);
-        virtual ~Scheduler ();
+        ~Scheduler () override;
 
         ExF::SchedulerResult open_scheduling_lane (
             std::string instance_id,

--- a/exf/tests/apc/asyn_multi_inher/sender/multi_inherit_sender_exec.h
+++ b/exf/tests/apc/asyn_multi_inher/sender/multi_inherit_sender_exec.h
@@ -184,7 +184,7 @@ namespace InterMulti_Sender_Impl
     AMI4CCM_OneReplyHandler_run_my_one_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : InterMulti_Sender_Impl::AMI4CCM_OneReplyHandler_run_my_one_i[ctor]
 
-    virtual ~AMI4CCM_OneReplyHandler_run_my_one_i ();
+    ~AMI4CCM_OneReplyHandler_run_my_one_i () override;
 
     void foo (
         int32_t ami_return_val,
@@ -222,7 +222,7 @@ namespace InterMulti_Sender_Impl
     AMI4CCM_TwoReplyHandler_run_my_two_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : InterMulti_Sender_Impl::AMI4CCM_TwoReplyHandler_run_my_two_i[ctor]
 
-    virtual ~AMI4CCM_TwoReplyHandler_run_my_two_i ();
+    ~AMI4CCM_TwoReplyHandler_run_my_two_i () override;
 
     void bar (
         const std::string& answer) override;
@@ -259,7 +259,7 @@ namespace InterMulti_Sender_Impl
     AMI4CCM_ThreeReplyHandler_run_my_three_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : InterMulti_Sender_Impl::AMI4CCM_ThreeReplyHandler_run_my_three_i[ctor]
 
-    virtual ~AMI4CCM_ThreeReplyHandler_run_my_three_i ();
+    ~AMI4CCM_ThreeReplyHandler_run_my_three_i () override;
 
     void plus (
         const std::string& answer) override;

--- a/exf/tests/apc/async-event-combi/components/sender/async_event_sender_exec.h
+++ b/exf/tests/apc/async-event-combi/components/sender/async_event_sender_exec.h
@@ -240,7 +240,7 @@ namespace Hello_Sender_Impl
     AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::AMI4CCM_MyFooReplyHandler_run_my_foo_i[ctor]
 
-    virtual ~AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
+    ~AMI4CCM_MyFooReplyHandler_run_my_foo_i () override;
 
     void foo (
         int32_t ami_return_val,

--- a/exf/tests/apc/minimal-async/components/sender/hello_sender_exec.h
+++ b/exf/tests/apc/minimal-async/components/sender/hello_sender_exec.h
@@ -141,7 +141,7 @@ namespace Hello_Sender_Impl
     AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
     //@@{__RIDL_REGEN_MARKER__} - END : Hello_Sender_Impl::AMI4CCM_MyFooReplyHandler_run_my_foo_i[ctor]
 
-    virtual ~AMI4CCM_MyFooReplyHandler_run_my_foo_i ();
+    ~AMI4CCM_MyFooReplyHandler_run_my_foo_i () override;
 
     void foo (
         int32_t ami_return_val,


### PR DESCRIPTION
    * exf/connectors/ami4ccm/tests/exf/hello_simple/receiver/hello_receiver_exec.h:
    * exf/connectors/ami4ccm/tests/exf/hello_simple/sender/hello_sender_exec.h:
    * exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_executors.h:
    * exf/connectors/dds4ccm/impl/exf/dds4ccm_exf_dds_event_strategies_t.h:
    * exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_executors.h:
    * exf/connectors/psdd4ccm/impl/exf/psdd4ccm_exf_event_strategies_t.h:
    * exf/deployment/amh/ciaox11_exf_exec_base.h:
    * exf/deployment/core/ciaox11_monitor_svc.h:
    * exf/deployment/core/ciaox11_schedule.h:
    * exf/deployment/core/ciaox11_scheduler_svc.h:
    * exf/deployment/handlers/ciaox11_exf_component_handler.h:
    * exf/deployment/handlers/ciaox11_exf_container.cpp:
    * exf/deployment/handlers/ciaox11_exf_container.h:
    * exf/deployment/handlers/ciaox11_exf_container_handler.h:
    * exf/deployment/logger/log.h:
    * exf/deployment/scheduler/ciaox11_exf_dispatcher.h:
    * exf/deployment/scheduler/ciaox11_exf_scheduler_i.cpp:
    * exf/deployment/scheduler/ciaox11_exf_scheduler_i.h:
    * exf/tests/apc/asyn_multi_inher/sender/multi_inherit_sender_exec.h:
    * exf/tests/apc/async-event-combi/components/sender/async_event_sender_exec.h:
    * exf/tests/apc/minimal-async/components/sender/hello_sender_exec.h: