### PR TITLE
Make use of C++11 using instead of typedef

### DIFF
--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/conn_templ/src/psdd4ccm/connector_pre_extra.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/conn_templ/src/psdd4ccm/connector_pre_extra.erb
@@ -1,8 +1,7 @@
 
 // generated from <%= ridl_template_path %>
-typedef <%= psdd4ccm_event_strategy_template %><
-    CCM_<%= scoped_cxxname.scope_to_cxxname %>_Traits> event_strategy_type;
+using event_strategy_type = typedef <%= psdd4ccm_event_strategy_template %><CCM_<%= scoped_cxxname.scope_to_cxxname %>_Traits>;
 
-typedef ::PSDD::traits<<%= template_args.first.cxx_type %>> topic_psdd_traits_type;
-typedef ::PSDD::ServiceHelper service_helper_type;
-typedef <%= scoped_enclosure_cxxname %>::CCM_Serializer custom_serializer_type;
+using topic_psdd_traits_type = ::PSDD::traits<<%= template_args.first.cxx_type %>>;
+using service_helper_type = ::PSDD::ServiceHelper;
+using custom_serializer_type = <%= scoped_enclosure_cxxname %>::CCM_Serializer;

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb
@@ -17,10 +17,9 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::false_type key_only;
-    typedef std::true_type no_key;
+    using key_only = std::false_type;
+    using no_key = std::true_type;
   };
-
 } // PSDD
 
 #endif

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb
@@ -8,8 +8,8 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::true_type key_only;
-    typedef std::false_type no_key;
+    using key_only = std::true_type;
+    using no_key = std::false_type;
 
     static
     bool append_key (

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb
@@ -15,10 +15,9 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::false_type key_only;
-    typedef std::true_type no_key;
+    using key_only = std::false_type;
+    using no_key = std::true_type;
   };
-
 } // PSDD
 
 #endif

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb
@@ -19,10 +19,9 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::true_type key_only;
-    typedef std::false_type no_key;
+    using key_only = std::true_type;
+    using no_key = std::false_type;
   };
-
 } // PSDD
 
 #endif

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb
@@ -8,8 +8,8 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::<%= has_key_only? %>_type key_only;
-    typedef std::<%= has_no_key? %>_type no_key;
+    using key_only = std::<%= has_key_only? %>_type;
+    using no_key = std::<%= has_no_key? %>_type;
 
     static
     bool append_key (

--- a/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb
+++ b/connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb
@@ -8,8 +8,8 @@ namespace PSDD
   {
     static std::string get_type_name () { return "<%= scoped_cxxname %>"; }
 
-    typedef std::false_type key_only;
-    typedef std::false_type no_key;
+    using key_only = std::false_type;
+    using no_key = std::false_type;
 
     static
     bool append_key (

--- a/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/templates/typesupport/src/ndds/factory_register_type.erb
+++ b/ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/templates/typesupport/src/ndds/factory_register_type.erb
@@ -1,10 +1,10 @@
 // generated from <%= ridl_template_path %>
-typedef DDSX11::DDS_TypeFactory_T <
+using DDS_type_factory_type = DDSX11::DDS_TypeFactory_T <
   <%= scoped_cxxtype %>,
   <%= scoped_seq_cxxtype %>,
   <%= native_scoped_seq_cxxtype %>,
   <%= native_scoped_name_prefix %>DataReader,
-  <%= native_scoped_name_prefix %>DataWriter> DDS_type_factory_type;
+  <%= native_scoped_name_prefix %>DataWriter>;
 
 std::shared_ptr<DDS_type_factory_type> factory {};
 

--- a/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/typesupport/src/opendds/factory_register_type.erb
+++ b/ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/typesupport/src/opendds/factory_register_type.erb
@@ -1,10 +1,10 @@
 // generated from <%= ridl_template_path %>
-typedef DDSX11::DDS_TypeFactory_T <
+using DDS_type_factory_type = DDSX11::DDS_TypeFactory_T <
   <%= scoped_cxxtype %>,
   <%= scoped_seq_cxxtype %>,
   <%= native_scoped_seq_cxxtype %>,
   <%= native_scoped_name_prefix %>DataReader,
-  <%= native_scoped_name_prefix %>DataWriter> DDS_type_factory_type;
+  <%= native_scoped_name_prefix %>DataWriter>;
 
 std::shared_ptr<DDS_type_factory_type> factory {};
 

--- a/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/hdr/exf/comp_facet.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/hdr/exf/comp_facet.erb
@@ -4,7 +4,7 @@
 % all_ports.each do |_p|
 %   if _p.port_type == :facet
 %     if _p.cxxname == 'ami4ccm_port_ami4ccm_provides'
-typedef std::vector<<%=_p.interface_type.scoped_ccm_name_member_type %>> <%= _p.cxxname %>_list_t;
+using <%= _p.cxxname %>_list_t = std::vector<<%=_p.interface_type.scoped_ccm_name_member_type %>>;
 <%= _p.cxxname %>_list_t <%= _p.cxxname %>_list_;
 %     else
 <%= _p.interface_type.scoped_ccm_name_member_type %> <%= _p.cxxname %>_;

--- a/exf/ridlbe/ccmx11/facets/exf4cc/templates/comp_exec/src/corba/exf/component_factory.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4cc/templates/comp_exec/src/corba/exf/component_factory.erb
@@ -2,14 +2,13 @@
 %# There's always one port
 % _p = all_ports[0] if !all_ports.empty?
 % _cc = _p.interface_type.scoped_cxxname.scope_to_cxxname + '_CorbaConnector'
-  typedef CCM_CORBA::CORBA_Connector_T<
+  using <%= _cc %> = CCM_CORBA::CORBA_Connector_T<
     <%= scoped_ccm_name %>,
     <%= scoped_ccm_name %>_Context,
     <%= _p.interface_type.scoped_ccm_name %>,
     <%= executor_cxx_namespace %>::<%= _p.lem_name %>_exec_i,
     <%= _p.resolved_cxxtype %>,
-    <%= _p.interface_type.scoped_cxxname.identify %>_servant>
-      <%= _cc %>;
+    <%= _p.interface_type.scoped_cxxname.identify %>_servant>;
 
   namespace ExF
   {
@@ -17,7 +16,7 @@
       : public <%= executor_cxx_namespace %>::<%= _cc %>
     {
     public:
-      typedef <%= executor_cxx_namespace %>::<%= _cc %> base_type;
+      using base_type = <%= executor_cxx_namespace %>::<%= _cc %>;
 
       <%= _cc %> () = default;
       ~<%= _cc %> () override = default;

--- a/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_attribute.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_attribute.erb
@@ -4,7 +4,7 @@ class <%= skel_export_macro %><%= interface.skel_cxxname %>_get_<%= cxxname %>_R
   : public <%= interface.skel_cxxname %>_RequestHandlerBase
 {
 public:
-  typedef std::shared_ptr<<%= interface.skel_cxxname %>_get_<%= cxxname %>_RequestHandler> ref_type;
+  using ref_type = std::shared_ptr<<%= interface.skel_cxxname %>_get_<%= cxxname %>_RequestHandler>;
 
   void init (TAO_ServerRequest&);
 
@@ -20,7 +20,7 @@ class <%= skel_export_macro %><%= interface.skel_cxxname %>_set_<%= cxxname %>_R
   : public <%= interface.skel_cxxname %>_RequestHandlerBase
 {
 public:
-  typedef std::shared_ptr<<%= interface.skel_cxxname %>_set_<%= cxxname %>_RequestHandler> ref_type;
+  using ref_type = std::shared_ptr<<%= interface.skel_cxxname %>_set_<%= cxxname %>_RequestHandler>;
 
   void init (TAO_ServerRequest&);
 

--- a/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_operation.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_operation.erb
@@ -4,7 +4,7 @@ class <%= skel_export_macro %><%= interface.skel_cxxname %>_<%= cxxname %>_Reque
   : public <%= interface.skel_cxxname %>_RequestHandlerBase
 {
 public:
-  typedef std::shared_ptr<<%= interface.skel_cxxname %>_<%= cxxname %>_RequestHandler> ref_type;
+  using ref_type = std::shared_ptr<<%= interface.skel_cxxname %>_<%= cxxname %>_RequestHandler>;
 
   void init (TAO_ServerRequest&);
 

--- a/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/interface_exf_pre.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/interface_exf_pre.erb
@@ -7,7 +7,7 @@ namespace ExF
     : public CIAOX11::ExF::Impl::RequestHandler
   {
   public:
-    typedef std::shared_ptr<<%= skel_cxxname %>_RequestHandlerBase> ref_type;
+    using ref_type = std::shared_ptr<<%= skel_cxxname %>_RequestHandlerBase>;
 
     virtual void execute (IDL::traits<::<%= scoped_cxxname %>>::ref_type&) = 0;
 

--- a/ridlbe/ccmx11/facets/ami4ccm/templates/lem_idl/ami/lem_extra_multiple_receptacles.erb
+++ b/ridlbe/ccmx11/facets/ami4ccm/templates/lem_idl/ami/lem_extra_multiple_receptacles.erb
@@ -5,7 +5,7 @@
     <%= port.interface_type.scoped_ami4ccm_name %> objref;
     Components::Cookie ck;
   };
-  using sendc_<%= port.lem_name %>Connections = sequence<sendc_<%= port.lem_name %>Connection>;
+  typedef sequence<sendc_<%= port.lem_name %>Connection> sendc_<%= port.lem_name %>Connections;
 
 % end
 %end

--- a/ridlbe/ccmx11/facets/ami4ccm/templates/lem_idl/ami/lem_extra_multiple_receptacles.erb
+++ b/ridlbe/ccmx11/facets/ami4ccm/templates/lem_idl/ami/lem_extra_multiple_receptacles.erb
@@ -5,7 +5,7 @@
     <%= port.interface_type.scoped_ami4ccm_name %> objref;
     Components::Cookie ck;
   };
-  typedef sequence<sendc_<%= port.lem_name %>Connection> sendc_<%= port.lem_name %>Connections;
+  using sendc_<%= port.lem_name %>Connections = sequence<sendc_<%= port.lem_name %>Connection>;
 
 % end
 %end


### PR DESCRIPTION
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/conn_templ/src/psdd4ccm/connector_pre_extra.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/array.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/enum.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/sequence.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/string.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/struct.erb:
    * connectors/psdd4ccm/ridlbe/ccmx11/facets/psdd4ccm/templates/psdd_traits/union.erb:
    * ddsx11/vendors/ndds/ridlbe/ccmx11/facets/dds4ndds/templates/typesupport/src/ndds/factory_register_type.erb:
    * ddsx11/vendors/opendds/ridlbe/ccmx11/facets/dds4opendds/templates/typesupport/src/opendds/factory_register_type.erb:
    * exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/hdr/exf/comp_facet.erb:
    * exf/ridlbe/ccmx11/facets/exf4cc/templates/comp_exec/src/corba/exf/component_factory.erb:
    * exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_attribute.erb:
    * exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/exf_operation.erb:
    * exf/ridlbe/ccmx11/facets/exf4cc/templates/srv/hdr/exf/interface_exf_pre.erb:
    * ridlbe/ccmx11/facets/ami4ccm/templates/lem_idl/ami/lem_extra_multiple_receptacles.erb: