### PR TITLE
make use of empty()

### DIFF
--- a/connectors/dds4ccm/tests/filters/common/read_get/receiver/filters_common_receiver_rg_runner_t.cpp
+++ b/connectors/dds4ccm/tests/filters/common/read_get/receiver/filters_common_receiver_rg_runner_t.cpp
@@ -182,7 +182,7 @@ ReadGetReceiverRunner_T<CONTEXT_TYPE, QUERY_ATTRIB>::check_filter (
           << std::endl;
         error = true;
       }
-      if (filter.parameters ().size () != 0)
+      if (!filter.parameters ().empty ())
       {
         DDS4CCM_TEST_ERROR << "ERROR: ReadGetReceiverRunner_T<CONTEXT_TYPE, QUERY_ATTRIB>::check_filter <"
           << port << "> - Unexpected parameter list: expected an "


### PR DESCRIPTION
    * connectors/dds4ccm/tests/filters/common/read_get/receiver/filters_common_receiver_rg_runner_t.cpp: