### PR TITLE
Reworked ami4ccm exf template, in some use cases a comma was missing, simplified the…

### DIFF
--- a/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/src/exf/exf_executor_operation.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/src/exf/exf_executor_operation.erb
@@ -1,30 +1,19 @@
 
   // generated from <%= ridl_template_path %>
-
 % _args = operation.arguments.dup
 % if operation.is_void?
 %     _arg_string = ""
 %     _arg_string_empty = 1
 %     _void_op_ = 1
 % else
-%     _arg_string = "#{operation.scoped_cxx_in_type} ami_return_val"
+%     _arg_string = "          #{operation.scoped_cxx_in_type} ami_return_val,"
 %     _arg_string_empty = 0
 %     _void_op = 0
 % end
-% _op_start ="          "
-% first = 0
-% first = 1
 % while !_args.empty?
 %   _arg = _args.shift
 %   if (_arg.direction == :out) || (_arg.direction == :inout)
-%     if _arg_string_empty == 1
-%      end_line = ""
-%     else
-%       end_line = ",\n"
-%       end_line << _op_start
-%     end
-%     _arg_string << end_line
-%     _arg_string << "#{_arg.scoped_cxx_in_type} #{_arg.cxxname},"
+%     _arg_string << "          #{_arg.scoped_cxx_in_type} #{_arg.cxxname},"
 %     _arg_string_empty = 0
 %   end
 % end
@@ -36,7 +25,7 @@
           std::string event_id,
           IDL::traits<<%= receptacle_port.interface_type.scoped_enclosure_cxxname %>::<%= receptacle_port.interface_type.ami4ccm_ReplyHandler %>>::ref_type callback,
 % if  _arg_string_empty == 0
-          <%= _arg_string %>
+<%= _arg_string %>
 % end
           CIAOX11::ExF::Deadline dead_line,
           CIAOX11::ExF::Priority priority)
@@ -46,12 +35,7 @@
 % end
 %   operation.arguments.each do |_arg|
 %       unless _arg.direction == :in
-%         if first == 0
-    <%= _arg.cxxname %>_(<%= _arg.cxxname %>)
-%         first = 1
-%         else
     , <%= _arg.cxxname %>_(<%= _arg.cxxname %>)
-%         end
 %       end
 %   end
     {}


### PR DESCRIPTION
… generation further

    * exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/src/exf/exf_executor_operation.erb: