### PR TITLE
Added the ExF test that uses a AMI4CCM/CORBA4CCM colocated, something…

### DIFF
--- a/exf/bin/exf_tests.lst
+++ b/exf/bin/exf_tests.lst
@@ -15,6 +15,7 @@ exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/run_test.pl plan_ope
 exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/run_test.pl plan_ndds.cdp: DDS4CCM_EVENT EXF4CCM NDDS
 exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/run_test.pl plan_opendds.cdp: DDS4CCM_EVENT EXF4CCM OPENDDS
 exf/connectors/ami4ccm/tests/exf/hello_simple/descriptors/run_test.pl plan.config: AMI4CCM CORBA4CCM EXF4CCM
+exf/connectors/ami4ccm/tests/exf/hello_simple/descriptors/run_test.pl plan_colocated_cc_sync.config: AMI4CCM CORBA4CCM EXF4CCM
 exf/connectors/corba4ccm/tests/exf/descriptors/run_test.pl plan.config: CORBA4CCM EXF4CCM
 exf/connectors/corba4ccm/tests/exf/descriptors/run_test.pl plan-no-exf.config: CORBA4CCM EXF4CCM
 exf/connectors/corba4ccm/tests/exf/descriptors/run_test.pl plan-full-exf.config: CORBA4CCM EXF4CCM

--- a/exf/connectors/ami4ccm/tests/exf/hello_simple/descriptors/plan_colocated_cc_sync.config
+++ b/exf/connectors/ami4ccm/tests/exf/hello_simple/descriptors/plan_colocated_cc_sync.config
@@ -20,6 +20,7 @@
 nl.remedy.it.DnCX11.LocalityManager SenderLocality
     nl.remedy.it.DnCX11.Node "SenderNode"
     nl.remedy.it.DnCX11.ExecParameter nl.remedy.it.DnCX11.Locality.ConfigFile "exf-localitymanager.config"
+    nl.remedy.it.DnCX11.ExecParameter nl.remedy.it.DnCX11.Locality.Arguments "-ORBAMICollocation 0"
 
 # ReceiverComponent instance
 nl.remedy.it.CCM.Component Hello_ReceiverComponent hello_exf_r_exec create_Hello_Receiver_Impl


### PR DESCRIPTION
… that shouldn't be done, but it is a reproducer for a possible problem with CORBA4CCM colocation

    * exf/bin/exf_tests.lst:
    * exf/connectors/ami4ccm/tests/exf/hello_simple/descriptors/plan_colocated_cc_sync.config: