### PR TITLE
Don't add the current directory to the include flags

### DIFF
--- a/brix/ciaox11/apc/mpcprojects/mpc_idl.rb
+++ b/brix/ciaox11/apc/mpcprojects/mpc_idl.rb
@@ -158,7 +158,7 @@ module AxciomaPC
       end
 
       def includes_flags
-        recipe.get_relative_paths(includes).collect { |idir| "-I#{idir}" }.join(' ')
+        recipe.get_relative_paths(includes).collect { |idir| "-I#{idir}" unless idir == '.' }.join(' ')
       end
 
       def idl_extras(extras = nil)


### PR DESCRIPTION
Adding the current directory ('.') is not necessary, first thought this was breaking rtiddsgen, but that seems to be a different issue.