### PR TITLE
Redirect some RTI Connext DDS logging to a log file

### DIFF
--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="defaultlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/event/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="defaultlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="defaultprofile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="defaultlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/listeners/state/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="defaultlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="defaultprofile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="defaultlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/filter_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="defaultlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="defaultprofile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="defaultlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/filters/query_attrib/read_get/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="defaultlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="defaultprofile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="samplelostlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="SampleLostProfile" is_default_qos="false">
       <!-- QoS used to configure the data writer created in the example code -->
       <participant_qos>

--- a/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="samplelostlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/port_status_listener/sample_lost/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="unkeyedwriterlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="UnkeyedWriterProfile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="unkeyedwriterlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/connectors/dds4ccm/tests/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
+++ b/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="shapes">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="ShapesProfile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
+++ b/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>

--- a/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
+++ b/ddsx11/tests/builtin/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="shapes">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/exf/brix/exf/apc/ports/port_type.rb
+++ b/exf/brix/exf/apc/ports/port_type.rb
@@ -8,6 +8,6 @@
 #--------------------------------------------------------------------
 
 # load all interaction pattern port type implementations
-Dir.glob(File.join(File.dirname(__FILE__), 'port_types', '*.rb')).each do |fnm|
+Dir.glob(File.join(File.dirname(__FILE__), 'port_types', '*.rb')).sort.each do |fnm|
   require fnm
 end

--- a/exf/brix/exf/apc/ports/port_types/corba4ccm_port.rb
+++ b/exf/brix/exf/apc/ports/port_types/corba4ccm_port.rb
@@ -52,7 +52,8 @@ module AxciomaPC
         def self.setup_data(recipe, fidl)
           # does the IDL file need full skeletons?
           if fidl.properties[:needs_skel]
-            if mpc_idl_obj = recipe.mpc_file[:skel_gen]
+            mpc_idl_obj = recipe.mpc_file[:skel_gen]
+            if mpc_idl_obj
               # check if ExF support flag needs to be added
               mpc_idl_obj.base_projects << 'ciaox11_exf_idl' if fidl.properties[:exf_skel]
               # now update the skel compiler project
@@ -60,7 +61,7 @@ module AxciomaPC
               # do we need ExF base project?
               mpc_skel_obj.base_projects << 'ciaox11_exf_amh' if fidl.properties[:exf_skel]
               # could be that we add this multiple times but that is no problem as
-              # #base_projects is a unique string list
+              # base_projects is a unique string list
             end
           end
         end

--- a/exf/brix/exf/apc/require.rb
+++ b/exf/brix/exf/apc/require.rb
@@ -8,11 +8,11 @@
 #--------------------------------------------------------------------
 
 # load all recipe specializations
-Dir.glob(File.join(File.dirname(__FILE__), 'recipes', '*.rb')).each do |fnm|
+Dir.glob(File.join(File.dirname(__FILE__), 'recipes', '*.rb')).sort.each do |fnm|
   require fnm
 end
 
 # load all port implementations
-Dir.glob(File.join(File.dirname(__FILE__), 'ports', '*.rb')).each do |fnm|
+Dir.glob(File.join(File.dirname(__FILE__), 'ports', '*.rb')).sort.each do |fnm|
   require fnm
 end

--- a/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -7,6 +7,17 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="rti_dds_qos_profiles.xsd" version="5.2.3">
   <qos_library name="unkeyedwriterlibrary">
+    <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
+      <!--
+      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
+      silent to not get false positives when running this unit test.
+      -->
+      <participant_factory_qos>
+      <logging>
+        <verbosity>SILENT</verbosity>
+      </logging>
+      </participant_factory_qos>
+    </qos_profile>
     <qos_profile name="UnkeyedWriterProfile" is_default_qos="false">
       <participant_qos>
         <transport_builtin>

--- a/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -9,8 +9,8 @@
   <qos_library name="unkeyedwriterlibrary">
     <qos_profile name="SilentLogging" is_default_participant_factory_profile="true">
       <!--
-      This test triggers RTI Connext DDS errors because it tests possible error situations, make the default logging
-      silent to not get false positives when running this unit test.
+      This test triggers RTI Connext DDS errors because it tests possible error situations, redirect the default logging
+      to nddslogging.log.
       -->
       <participant_factory_qos>
       <logging>

--- a/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
+++ b/exf/connectors/dds4ccm/tests/exf/unkeyed_writer/descriptors/USER_QOS_PROFILES.xml
@@ -14,7 +14,7 @@
       -->
       <participant_factory_qos>
       <logging>
-        <verbosity>SILENT</verbosity>
+        <output_file>nddslogging.log</output_file>
       </logging>
       </participant_factory_qos>
     </qos_profile>


### PR DESCRIPTION
RTI Connext DDS logging is not silent by default. In order to not get false positive test errors the tests that test whether we throw the correct exceptions redirect their RTI Connext DDS logging to a log file to not get false positives as part of our CI tests.