### PR TITLE
Removed redundant typedefs, using std::pair{} insert

### DIFF
--- a/ciaox11/deployment/handlers/ciaox11_component_handler.cpp
+++ b/ciaox11/deployment/handlers/ciaox11_component_handler.cpp
@@ -375,10 +375,8 @@ namespace CIAOX11
     CIAOX11_LOG_DEBUG ("Component_Handler::install_instance - " <<
                        "Starting installation for <" << idd.name () << ">");
 
-    DAnCEX11::Utility::build_property_map (info.pmap,
-                                        mdd.execParameter ());
-    DAnCEX11::Utility::build_property_map (info.pmap,
-                                        idd.configProperty ());
+    DAnCEX11::Utility::build_property_map (info.pmap, mdd.execParameter ());
+    DAnCEX11::Utility::build_property_map (info.pmap, idd.configProperty ());
 
     std::string exec_art, exec_entry, svnt_art, svnt_entry, cont_id, tmp, error_string;
 

--- a/ciaox11/deployment/handlers/ciaox11_state.cpp
+++ b/ciaox11/deployment/handlers/ciaox11_state.cpp
@@ -40,9 +40,9 @@ namespace CIAOX11
                          "attempting to add duplicate container reference");
     }
 
-    this->containers_.insert (CONTAINERS_PAIR (id, container));
+    this->containers_.insert (std::pair{id, container});
 
-    this->container_config_.insert (CONFIG_PAIR (id, std::move (config)));
+    this->container_config_.insert (std::pair{id, std::move (config)});
   }
 
   void
@@ -94,9 +94,9 @@ namespace CIAOX11
   {
     std::lock_guard<std::mutex> lock (this->state_mutex_);
 
-    this->instance_container_.insert (INSTANCE_PAIR (id, cont_id));
+    this->instance_container_.insert (std::pair{id, cont_id});
 
-    this->instance_config_.insert (CONFIG_PAIR (id, std::move (config)));
+    this->instance_config_.insert (std::pair{id, std::move (config)});
   }
 
   void

--- a/ciaox11/deployment/handlers/ciaox11_state.h
+++ b/ciaox11/deployment/handlers/ciaox11_state.h
@@ -80,7 +80,6 @@ namespace CIAOX11
     std::mutex state_mutex_;
 
     /// Container administration
-    using CONTAINERS_PAIR = std::pair <std::string, std::shared_ptr<CIAOX11::Container>>;
     using CONTAINERS = std::map <std::string, std::shared_ptr<CIAOX11::Container>>;
 
     CONTAINERS containers_;
@@ -88,16 +87,16 @@ namespace CIAOX11
     /// Administration which components are instantiated in which container
     using INSTANCE_CONTAINER = std::map <std::string, std::string>;
 
-    /// maps instance ids to containers.
+    /// Maps instance ids to containers.
     INSTANCE_CONTAINER instance_container_;
 
     /// Administers configuration of instances
     using INSTANCE_CONFIG = std::map <std::string, Components::ConfigValues>;
 
-    /// maps container ids to configuration.
+    /// Maps container ids to configuration.
     INSTANCE_CONFIG container_config_;
 
-    /// maps instance ids to configuration.
+    /// Maps instance ids to configuration.
     INSTANCE_CONFIG instance_config_;
   };
 

--- a/ciaox11/deployment/handlers/ciaox11_state.h
+++ b/ciaox11/deployment/handlers/ciaox11_state.h
@@ -86,14 +86,12 @@ namespace CIAOX11
     CONTAINERS containers_;
 
     /// Administration which components are instantiated in which container
-    using INSTANCE_PAIR = std::pair <std::string, std::string>;
     using INSTANCE_CONTAINER = std::map <std::string, std::string>;
 
     /// maps instance ids to containers.
     INSTANCE_CONTAINER instance_container_;
 
     /// Administers configuration of instances
-    using CONFIG_PAIR = std::pair <std::string, Components::ConfigValues>;
     using INSTANCE_CONFIG = std::map <std::string, Components::ConfigValues>;
 
     /// maps container ids to configuration.

--- a/connectors/dds4ccm/impl/dds4ccm_base_connector_t.cpp
+++ b/connectors/dds4ccm/impl/dds4ccm_base_connector_t.cpp
@@ -485,11 +485,9 @@ DDS_Base_Connector_T<CCM_TYPE>::activate_topic (
   if (mask != ::DDS::STATUS_MASK_NONE)
   {
     topic_listener =
-      DDS::make_reference<topic_listener_type>(
-        event_strategy_type (this->context_));
+      DDS::make_reference<topic_listener_type>(event_strategy_type (this->context_));
 
-    ::DDS::ReturnCode_t const retcode = topic->set_listener (
-      topic_listener, mask);
+    ::DDS::ReturnCode_t const retcode = topic->set_listener (topic_listener, mask);
 
     if (retcode != DDS::RETCODE_OK)
     {

--- a/connectors/psdd4ccm/impl/psdd4ccm_config_util.h
+++ b/connectors/psdd4ccm/impl/psdd4ccm_config_util.h
@@ -16,14 +16,12 @@ namespace PSDD
 {
   namespace Util
   {
-    typedef std::pair<std::string, CORBA::Any> property_pair_t;
     typedef std::map<std::string, CORBA::Any> property_map_t;
 
-    inline void build_property_map (const ::Components::ConfigValues &values,
-                                    property_map_t& map)
+    inline void build_property_map (const ::Components::ConfigValues &values, property_map_t& map)
     {
       for (const ::Components::ConfigValue& v : values)
-        map.insert (property_pair_t (v.name (), v.value ()));
+        map.insert (std::pair{v.name (), v.value ()});
     }
 
   }

--- a/exf/connectors/tt4ccm/impl/exf/ciaox11_timed_trigger_exf_exec.cpp
+++ b/exf/connectors/tt4ccm/impl/exf/ciaox11_timed_trigger_exf_exec.cpp
@@ -84,7 +84,6 @@ namespace CIAOX11_TT_TimedTrigger_Impl
     return {};
   }
 
-   // generated from ccmx11/exf4cc/comp_exec/src/corba/exf/component_extra_impl.erb
    void tt_scheduler_exec_i::set_config (
        const ::Components::ConfigValues& config)
    {

--- a/exf/deployment/handlers/ciaox11_exf_component_handler.cpp
+++ b/exf/deployment/handlers/ciaox11_exf_component_handler.cpp
@@ -30,10 +30,8 @@ namespace CIAOX11
       CIAOX11_LOG_DEBUG ("ExF::Component_Handler::install_instance - " <<
                          "Starting installation for <" << idd.name () << ">");
 
-      DAnCEX11::Utility::build_property_map (info.pmap,
-                                          mdd.execParameter ());
-      DAnCEX11::Utility::build_property_map (info.pmap,
-                                          idd.configProperty ());
+      DAnCEX11::Utility::build_property_map (info.pmap, mdd.execParameter ());
+      DAnCEX11::Utility::build_property_map (info.pmap, idd.configProperty ());
 
       std::string exec_art, exec_entry, svnt_art, svnt_entry, cont_id, tmp, error_string;
 

--- a/exf/deployment/scheduler/ciaox11_exf_dispatcher.cpp
+++ b/exf/deployment/scheduler/ciaox11_exf_dispatcher.cpp
@@ -806,7 +806,7 @@ namespace CIAOX11
           else
           {
             inst = std::make_shared<Instance> (instance_id, concurrent);
-            this->instance_map_.insert (INSTANCE_PAIR (instance_id, inst));
+            this->instance_map_.insert (std::pair{instance_id, inst});
           }
 
           Dispatcher::ref_type self_ref = this->self_.lock ();

--- a/exf/deployment/scheduler/ciaox11_exf_dispatcher.h
+++ b/exf/deployment/scheduler/ciaox11_exf_dispatcher.h
@@ -398,7 +398,6 @@ namespace CIAOX11
         std::vector<std::thread> threads_ {};
         std::atomic<size_t> thread_num_ {};
 
-        using INSTANCE_PAIR = std::pair<std::string, instance_ref>;
         using INSTANCE_MAP = std::map<std::string, instance_ref>;
 
         INSTANCE_MAP instance_map_ {};

--- a/exf/deployment/scheduler/ciaox11_exf_scheduler_i.cpp
+++ b/exf/deployment/scheduler/ciaox11_exf_scheduler_i.cpp
@@ -426,7 +426,7 @@ namespace CIAOX11
               }
 
               // register group dispatcher
-              this->groups_.insert (GROUP_PAIR (lane_group, GROUP_ENTRY {dispatcher}));
+              this->groups_.insert (std::pair{lane_group, GROUP_ENTRY {dispatcher}});
 
               CIAOX11_EXF_LOG_DEBUG ("ExF::Impl::Scheduler::open_scheduling_lane - "\
                                  "opening dispatch gate for " << instance_id <<
@@ -517,7 +517,7 @@ namespace CIAOX11
             CIAOX11_EXF_LOG_DEBUG ("ExF::Impl::Scheduler::open_scheduling_lane - "\
                                "registering scheduling lane for " << instance_id);
             // register lane
-            this->lanes_.insert (LANE_PAIR (instance_id, lane_entry));
+            this->lanes_.insert (std::pair{instance_id, lane_entry});
             std::swap (lane, lane_entry.lane_);
           }
         } // leave lock scope

--- a/exf/deployment/scheduler/ciaox11_exf_scheduler_i.h
+++ b/exf/deployment/scheduler/ciaox11_exf_scheduler_i.h
@@ -94,7 +94,6 @@ namespace CIAOX11
           std::string group_ {};
         };
 
-        using LANE_PAIR = std::pair<std::string, LANE_ENTRY>;
         using LANE_MAP = std::map<std::string, LANE_ENTRY>;
 
         struct GROUP_ENTRY
@@ -108,7 +107,6 @@ namespace CIAOX11
           uint32_t lane_count_ {};
         };
 
-        using GROUP_PAIR = std::pair<std::string, GROUP_ENTRY>;
         using GROUP_MAP = std::map<std::string, GROUP_ENTRY>;
 
         LANE_MAP lanes_ {};

--- a/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/hdr/exf/facet_exec.erb
+++ b/exf/ridlbe/ccmx11/facets/exf4ami/templates/acon/hdr/exf/facet_exec.erb
@@ -31,8 +31,7 @@ public:
   //@}
 
 %end
-  void
-  set_config(const ::Components::ConfigValues& config);
+  void set_config(const ::Components::ConfigValues& config);
 
 private:
   /// Context for component instance. Used for all middleware communication.


### PR DESCRIPTION
    * ciaox11/deployment/handlers/ciaox11_state.cpp:
    * ciaox11/deployment/handlers/ciaox11_state.h:
    * connectors/dds4ccm/impl/dds4ccm_base_connector_t.cpp:
    * exf/deployment/scheduler/ciaox11_exf_dispatcher.cpp:
    * exf/deployment/scheduler/ciaox11_exf_dispatcher.h: