### PR TITLE
Only extend the AMI4CCM production rules for ExF when gen_ami_connect…

### DIFF
--- a/exf/ridlbe/ccmx11/facets/exf4ami/config.rb
+++ b/exf/ridlbe/ccmx11/facets/exf4ami/config.rb
@@ -45,15 +45,17 @@ module IDL
         #
         fctcfg.on_process_input do |_parser, options|
           if options.gen_exf_support
-            if options[:gen_component_servant]
+            if options[:gen_ami_connector_impl]
               IDL.log(2, 'Extending ami4ccm connector executor generation for ExF')
 
               IDL.production(:ami4ccm_conn_header).extend(IDL::CCMX11::ExF::AmiExFConnectorHeaderWriter)
               IDL.production(:ami4ccm_conn_source).extend(IDL::CCMX11::ExF::AmiExFConnectorSourceWriter)
 
-              IDL.log(2, 'Extending ami4ccm connector servant generation for ExF')
-              # extend standard generators for AMI4CCM
-              IDL.production(:comp_svnt_source).extend(IDL::CCMX11::ExF::AmiExFSvntConnectorSourceExt)
+              if options[:gen_component_servant]
+                IDL.log(2, 'Extending ami4ccm connector servant generation for ExF')
+                # extend standard generators for AMI4CCM
+                IDL.production(:comp_svnt_source).extend(IDL::CCMX11::ExF::AmiExFSvntConnectorSourceExt)
+              end
             end
           end
         end # fctcfg.on_process_input


### PR DESCRIPTION
…or_impl has been set, at that moment we are generating an AMI4CCM connector

    * exf/ridlbe/ccmx11/facets/exf4ami/config.rb:

Fixed a problem when generating a DDS4CCM connector and using -Gsvnt as additional argument on the commandline