### PR TITLE
Reworked annotation generation for implied DDS IDL

### DIFF
--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/bitmask.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/bitmask.erb
@@ -1,7 +1,9 @@
 
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-@bit_bound(<%= bitbound_bits %>)
+% annotations.each do |_a|
+@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
+% end
 bitmask <%= unescaped_name %> {
   <%= bitvalues.collect {|e| "/// @copydoc #{e.doc_scoped_name}\n  #{e.name}" }.join(",\n  ") %>
 };

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/enum.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/enum.erb
@@ -1,7 +1,9 @@
 
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-@bit_bound(<%= bitbound_bits %>)
+% annotations.each do |_a|
+@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
+% end
 enum <%= unescaped_name %> {
   <%= enumerators.collect {|e| "/// @copydoc #{e.doc_scoped_name}\n  #{e.name}" }.join(",\n  ") %>
 };

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -1,6 +1,5 @@
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-@nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
 % annotations.each do |_a|
 @<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
 % end
@@ -8,7 +7,7 @@ struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><
 % members.each do |_m|
   /// @copydoc <%= _m.doc_scoped_name %>
 % _m.annotations.each do |_a|
-  @<%= _a.id %><% unless _a.fields.empty? %><% _a.fields.values.each do |f| %><%= f %><% end %><% end %>
+  @<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
 % end
   <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -2,13 +2,13 @@
 /// @copydoc <%= doc_scoped_name %>
 @nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
 % annotations.each do |_a|
-@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.each do |f| %><%= f %><% end %>)<% end %>
+@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
 % end
 struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><% end %> {
 % members.each do |_m|
   /// @copydoc <%= _m.doc_scoped_name %>
 % _m.annotations.each do |_a|
-  @<%= _a.id %><% unless _a.fields.empty? %><% _a.fields.each do |f| %><%= f %><% end %><% end %>
+  @<%= _a.id %><% unless _a.fields.empty? %><% _a.fields.values.each do |f| %><%= f %><% end %><% end %>
 % end
   <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -11,9 +11,12 @@ FI <%= f %>
 struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><% end %> {
 % members.each do |_m|
   /// @copydoc <%= _m.doc_scoped_name %>
-% _m.annotations.each do |a|
-DO <%= a.id %>
+% _m.annotations.each do |_a|
+  @<%= _a.id %><% unless _a.fields.empty? %><% end %><% _a.fields.each do |f| %><%= f %><% end %>
 % end
-  <% if _m.has_key_annotation? %>@key <% end %><%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
+  <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end
 };
+
+
+

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -2,9 +2,18 @@
 /// @copydoc <%= doc_scoped_name %>
 @nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
 @<%= extensibility_annotation %>
+% annotations.each do |a|
+DO <%= a.id %>
+% a.fields.each do |f|
+FI <%= f %>
+% end
+% end
 struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><% end %> {
 % members.each do |_m|
   /// @copydoc <%= _m.doc_scoped_name %>
+% _m.annotations.each do |a|
+DO <%= a.id %>
+% end
   <% if _m.has_key_annotation? %>@key <% end %><%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end
 };

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -1,18 +1,14 @@
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
 @nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
-@<%= extensibility_annotation %>
-% annotations.each do |a|
-DO <%= a.id %>
-% a.fields.each do |f|
-FI <%= f %>
-% end
+% annotations.each do |_a|
+@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.each do |f| %><%= f %><% end %>)<% end %>
 % end
 struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><% end %> {
 % members.each do |_m|
   /// @copydoc <%= _m.doc_scoped_name %>
 % _m.annotations.each do |_a|
-  @<%= _a.id %><% unless _a.fields.empty? %><% end %><% _a.fields.each do |f| %><%= f %><% end %>
+  @<%= _a.id %><% unless _a.fields.empty? %><% _a.fields.each do |f| %><%= f %><% end %><% end %>
 % end
   <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/struct.erb
@@ -13,6 +13,3 @@ struct <%= unescaped_name %><% unless base.nil? %> : <%= base.unescaped_name %><
   <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end
 };
-
-
-

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/union.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/union.erb
@@ -1,7 +1,6 @@
 
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
-@nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
 % annotations.each do |_a|
 @<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
 % end
@@ -15,6 +14,9 @@ union <%= unescaped_name %> switch (<%= strip_global_scope(switchtype.idltype_un
 %     end
 %   end
     /// @copydoc <%= _m.doc_scoped_name %>
+% _m.annotations.each do |_a|
+    @<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
+% end
     <%= strip_global_scope(_m.idltype_unescaped_name) %> <%= _m.unescaped_name %>;
 % end
 };

--- a/ridlbe/ccmx11/facets/dds/templates/idl/dds/union.erb
+++ b/ridlbe/ccmx11/facets/dds/templates/idl/dds/union.erb
@@ -2,7 +2,9 @@
 // generated from <%= ridl_template_path %>
 /// @copydoc <%= doc_scoped_name %>
 @nested(<% if has_toplevel_annotation? %>FALSE<% else %>TRUE<% end %>)
-@<%= extensibility_annotation %>
+% annotations.each do |_a|
+@<%= _a.id %><% unless _a.fields.empty? %>(<% _a.fields.values.each do |f| %><%= f %><% end %>)<% end %>
+% end
 union <%= unescaped_name %> switch (<%= strip_global_scope(switchtype.idltype_unescaped_name) %>) {
 % members.each do |_m|
 %   if _m.is_default?

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -70,10 +70,14 @@ module IDL
         :appendable
       end
 
-      # def annotations
+      def annotations
       # Add appendable when it is not final available
-      #   return []
-      # end
+         ann = self.annotations.dup
+         unless ann[:'final'].first
+           ann << Annotation.new('appendable')
+         end
+         ann
+      end
 
       def typesupport_export_include?
         params[:typesupport_export_include]

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -57,7 +57,7 @@ module IDL
 
       def has_toplevel_annotation?
         # 20190730 Add support for AXCIOMA 2 top-level annotation, issue #4729
-        annot = self.annotations[:'top-level'].first || self.annotations[:TopLevel].first
+        annot = node.annotations[:'top-level'].first || node.annotations[:TopLevel].first
         return false if annot.nil?
 
         annot.fields[:value].nil? || annot.fields[:value]

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -70,15 +70,6 @@ module IDL
         :appendable
       end
 
-      def annotations
-      # Add appendable when it is not final available
-         ann = self.annotations.dup
-         unless ann[:'final'].first
-           ann << Annotation.new('appendable')
-         end
-         ann
-      end
-
       def typesupport_export_include?
         params[:typesupport_export_include]
       end

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -70,9 +70,10 @@ module IDL
         :appendable
       end
 
-      def annotations
-        return []
-      end
+      # def annotations
+      # Add appendable when it is not final available
+      #   return []
+      # end
 
       def typesupport_export_include?
         params[:typesupport_export_include]

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -70,6 +70,10 @@ module IDL
         :appendable
       end
 
+      def annotations
+        return []
+      end
+
       def typesupport_export_include?
         params[:typesupport_export_include]
       end

--- a/ridlbe/ccmx11/facets/dds/visitorbase.rb
+++ b/ridlbe/ccmx11/facets/dds/visitorbase.rb
@@ -63,13 +63,6 @@ module IDL
         annot.fields[:value].nil? || annot.fields[:value]
       end
 
-      def extensibility_annotation
-        # DDS X-Types defines that the default for extensibility is appendable
-        return :final if self.annotations[:'final'].first
-
-        :appendable
-      end
-
       def typesupport_export_include?
         params[:typesupport_export_include]
       end

--- a/ridlbe/ccmx11/facets/dds/visitors/struct.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/struct.rb
@@ -24,9 +24,10 @@ module IDL
          unless ann[:'final'].first
            ann << IDL::AST::Annotation.new('appendable', {})
          end
-         #if has_toplevel_annotation?
-           ann << IDL::AST::Annotation.new('nested', {v: 'FALSE'})
-         #end
+         # Determine correct value for DDS nested annotation
+         nested = 'TRUE'
+         nested = 'FALSE' if has_toplevel_annotation?
+         ann << IDL::AST::Annotation.new('nested', {v: nested})
          ann
       end
     end # StructVisitor

--- a/ridlbe/ccmx11/facets/dds/visitors/struct.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/struct.rb
@@ -17,6 +17,15 @@ module IDL
       include CcmNames
 
       optional_template :life_cycle_traits
+
+      def annotations
+        # Add appendable when it is not final available
+         ann = node.annotations.dup
+         unless ann[:'final'].first
+           ann << IDL::AST::Annotation.new('appendable', {})
+         end
+         ann
+      end
     end # StructVisitor
 
     class StructMemberVisitor

--- a/ridlbe/ccmx11/facets/dds/visitors/struct.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/struct.rb
@@ -30,11 +30,5 @@ module IDL
          ann
       end
     end # StructVisitor
-
-    class StructMemberVisitor
-      def has_key_annotation?
-        !self.annotations[:key].empty?
-      end
-    end
   end # CCMX11
 end # IDL

--- a/ridlbe/ccmx11/facets/dds/visitors/struct.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/struct.rb
@@ -24,6 +24,9 @@ module IDL
          unless ann[:'final'].first
            ann << IDL::AST::Annotation.new('appendable', {})
          end
+         #if has_toplevel_annotation?
+           ann << IDL::AST::Annotation.new('nested', {v: 'FALSE'})
+         #end
          ann
       end
     end # StructVisitor

--- a/ridlbe/ccmx11/facets/dds/visitors/union.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/union.rb
@@ -24,6 +24,19 @@ module IDL
       def is_array_type?
         ::IDL::Type::Array === self._resolved_idltype
       end
+
+      def annotations
+        # Add appendable when it is not final available
+         ann = node.annotations.dup
+         unless ann[:'final'].first
+           ann << IDL::AST::Annotation.new('appendable', {})
+         end
+         # Determine correct value for DDS nested annotation
+         nested = 'TRUE'
+         nested = 'FALSE' if has_toplevel_annotation?
+         ann << IDL::AST::Annotation.new('nested', {v: nested})
+         ann
+      end
     end
 
     class UnionVisitor

--- a/ridlbe/ccmx11/facets/dds/visitors/union.rb
+++ b/ridlbe/ccmx11/facets/dds/visitors/union.rb
@@ -24,6 +24,14 @@ module IDL
       def is_array_type?
         ::IDL::Type::Array === self._resolved_idltype
       end
+    end
+
+    class UnionVisitor
+      def native_scoped_switch_cxxtype
+        self.switchtype.is_a?(::IDL::Type::ScopedName) ? '::DDS_Native' + scoped_switch_cxxtype : scoped_switch_cxxtype
+      end
+
+      optional_template :life_cycle_traits
 
       def annotations
         # Add appendable when it is not final available
@@ -37,14 +45,6 @@ module IDL
          ann << IDL::AST::Annotation.new('nested', {v: nested})
          ann
       end
-    end
-
-    class UnionVisitor
-      def native_scoped_switch_cxxtype
-        self.switchtype.is_a?(::IDL::Type::ScopedName) ? '::DDS_Native' + scoped_switch_cxxtype : scoped_switch_cxxtype
-      end
-
-      optional_template :life_cycle_traits
     end
   end # CCMX11
 end # IDL


### PR DESCRIPTION
Reworked the annotation generation for the implied DDS IDL. Instead of handling some possible annotations just add the DDS required annotations and let the templates just loop through all annotations, makes it much easier to support all new IDL4 annotations