### PR TITLE
Move -namespace argument for rtiddsgen to this file, it is for the C+…

### DIFF
--- a/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
+++ b/ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------
 
 feature(ddsx11, ndds) : ndds_ts_defaults {
-  ndds_ts_flags += -enableEscapeChar -typeSequenceSuffix RTISeq -language C++
+  ndds_ts_flags += -enableEscapeChar -typeSequenceSuffix RTISeq -language C++ -namespace
   Define_Custom(TypeSupport) {
   }
   Define_Custom(DummyTypeSupport) {


### PR DESCRIPTION
…+98 mapping only

    * ddsx11/vendors/ndds/MPC/config/ddsx11_vendor_ts_defaults.mpb: