### PR TITLE
Add logging when the last character of the b_57 string is zero

### DIFF
--- a/connectors/dds4ccm/tests/idl_conversion/receiver/idl_conversion_receiver_exec.cpp
+++ b/connectors/dds4ccm/tests/idl_conversion/receiver/idl_conversion_receiver_exec.cpp
@@ -454,6 +454,14 @@ namespace IDL_Conversion_Test_Receiver_Impl
       const std::string expected ("VALUE_"+std::to_string (datum.iteration () + c));
       if (val != expected)
       {
+        if (!val.empty ())
+        {
+          if (val.back() == 0)
+          {
+            DDS4CCM_TEST_ERROR << "Receiver check - ERROR: last character of "
+              << "datum.b_57[" << c << "] is 0"  << std::endl;
+          }
+        }
         DDS4CCM_TEST_ERROR << "Receiver check - ERROR: unexpected value for "
           << "datum.b_57[" << c << "]: expected <" << expected << "> - got <"
           << val << ">" << std::endl;


### PR DESCRIPTION
    * connectors/dds4ccm/tests/idl_conversion/receiver/idl_conversion_receiver_exec.cpp: